### PR TITLE
Skeleton: cobra CLI, public types in pkg/acmm, stub subcommands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: gofmt
+        run: |
+          fmt_out="$(gofmt -l .)"
+          if [ -n "$fmt_out" ]; then
+            echo "::error::gofmt found unformatted files:"
+            echo "$fmt_out"
+            exit 1
+          fi
+
+      - name: vet
+        run: go vet ./...
+
+      - name: build
+        run: go build ./...
+
+      - name: test
+        run: go test -race -count=1 ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Binaries
+/plumbline
+/dist/
+/build/
+
+# Test artifacts
+*.test
+*.out
+coverage.txt
+coverage.html
+
+# OS / editor
+.DS_Store
+*.swp
+.idea/
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: build test test-race lint vet tidy clean install help
+
+BIN := plumbline
+PKG := github.com/sroberts/plumbline
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+LDFLAGS := -X $(PKG)/internal/buildinfo.Version=$(VERSION) -X $(PKG)/internal/buildinfo.Commit=$(COMMIT)
+
+build:
+	go build -ldflags='$(LDFLAGS)' -o $(BIN) ./cmd/plumbline
+
+install:
+	go install -ldflags='$(LDFLAGS)' ./cmd/plumbline
+
+test:
+	go test ./...
+
+test-race:
+	go test -race ./...
+
+vet:
+	go vet ./...
+
+tidy:
+	go mod tidy
+
+lint: vet
+	@command -v golangci-lint >/dev/null && golangci-lint run || echo "(golangci-lint not installed; ran go vet only)"
+
+clean:
+	rm -f $(BIN)
+	rm -rf dist build
+
+help:
+	@echo "Targets: build test test-race vet tidy lint clean install"

--- a/cmd/plumbline/assess.go
+++ b/cmd/plumbline/assess.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+func newAssessCmd(stdout, stderr io.Writer) *cobra.Command {
+	var (
+		asJSON         bool
+		reportFmt      string
+		outPath        string
+		eventsFmt      string
+		quiet          bool
+		noColor        bool
+		cli            bool
+		tui            bool
+		failBelow      int
+		profile        string
+		configPath     string
+		minConfidence  string
+		signalSet      string
+		ciSystem       string
+		debug          bool
+		clock          string
+		includeSignal  []string
+		excludeSignal  []string
+		levelFilters   []int
+		familyFilters  []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "assess [path]",
+		Short: "Scan a repo and report its ACMM maturity level",
+		Long: `plumbline assess — scan a repo and report its ACMM maturity level.
+
+Walks the repository at [path] (default ".") and runs every enabled
+signal detector against it. Produces a verdict (level 1-5), per-level
+scores, and the list of signals that would unlock the next level.
+
+Mode is auto-detected: TUI on a terminal, CLI when piped or in CI.
+Use --cli to force non-interactive output, --tui to force the TUI.
+
+Examples:
+  # Interactive TUI: scan the current directory.
+  plumbline assess
+
+  # Machine-readable, with progress events on stderr.
+  plumbline assess --json --events ndjson 2>events.log >verdict.json
+
+  # CI gate: fail if not at level 3 or higher.
+  plumbline assess --fail-below 3 --quiet
+
+  # Scan a specific repo, save markdown report.
+  plumbline assess /path/to/repo --report markdown --out maturity.md
+
+  # Only run the L3 coverage signals.
+  plumbline assess --level 3 --family coverage --json
+
+Exit codes:
+  0  scan completed; gate passed (or no gate set)
+  1  scan completed; gate failed (assessed level < --fail-below)
+  2  could not run (path not a directory, IO error)
+  3  configuration error
+
+See also:
+  plumbline inspect          drill into one signal's evidence
+  plumbline signals          list every signal the tool detects
+  plumbline help scoring     how levels and the no-skip rule are computed
+  plumbline help agents      guidance for LLM tool callers`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			// Cross-flag validation that's true regardless of milestone.
+			if cli && tui {
+				return errCannotRun(errors.New("--cli and --tui are mutually exclusive"))
+			}
+			if len(includeSignal) > 0 && len(excludeSignal) > 0 {
+				return errCannotRun(errors.New("--include-signal and --exclude-signal are mutually exclusive"))
+			}
+			fmt.Fprintln(stderr, "(M1: assess is wired up but the scanner and signals land in the next PR)")
+			fmt.Fprintln(stderr, "Hint: run 'plumbline help' for the topic index.")
+			return errCannotRun(errors.New("not implemented in this milestone"))
+		},
+	}
+
+	f := cmd.Flags()
+	f.BoolVar(&asJSON, "json", false, "Emit JSON to stdout. Implies --cli. Schema: 'plumbline schema verdict'.")
+	f.StringVar(&reportFmt, "report", "", "Write a report file. fmt: markdown|json|sarif. Implies --cli.")
+	f.StringVar(&outPath, "out", "-", "Report destination. \"-\" = stdout.")
+	f.StringVar(&eventsFmt, "events", "", "Stream progress events to stderr. fmt: ndjson|text. Schema: 'plumbline schema event'.")
+	f.BoolVarP(&quiet, "quiet", "q", false, "Suppress banners, progress, and trailing hints. Implies --cli.")
+	f.BoolVar(&noColor, "no-color", false, "Disable ANSI color (also via NO_COLOR=1).")
+	f.BoolVar(&cli, "cli", false, "Force pure-CLI mode. Auto-set when stdout is not a TTY.")
+	f.BoolVar(&tui, "tui", false, "Force TUI even when stdout is not a TTY.")
+	f.IntVar(&failBelow, "fail-below", 0, "Exit 1 if assessed level < N (2-5). 0 = no gate.")
+	f.StringVar(&profile, "profile", "default", "Named signal preset. See 'plumbline help profiles'.")
+	f.StringVar(&configPath, "config", "", "Override config path. Default: .plumbline.yml.")
+	f.StringVar(&minConfidence, "min-confidence", "low", "Minimum confidence to credit a signal: low|medium|high.")
+	f.StringVar(&signalSet, "signal-set", "latest", "Pin signal rule-set version (e.g., v1).")
+	f.StringVar(&ciSystem, "ci-system", "auto", "CI flavor: auto|github-actions. Other systems are M4+.")
+	f.BoolVar(&debug, "debug", false, "Emit detection diagnostics on stderr. Implies --cli.")
+	f.StringVar(&clock, "clock", "wall", "Timestamp source for events: wall|fixed|relative.")
+	f.StringSliceVar(&includeSignal, "include-signal", nil, "Only run the listed signals. Repeatable.")
+	f.StringSliceVar(&excludeSignal, "exclude-signal", nil, "Skip the listed signals. Repeatable.")
+	f.IntSliceVar(&levelFilters, "level", nil, "Only run signals at level N (2-5). Repeatable.")
+	f.StringSliceVar(&familyFilters, "family", nil, "Only run signals in family <name>. Repeatable.")
+
+	return cmd
+}

--- a/cmd/plumbline/assess.go
+++ b/cmd/plumbline/assess.go
@@ -10,26 +10,26 @@ import (
 
 func newAssessCmd(stdout, stderr io.Writer) *cobra.Command {
 	var (
-		asJSON         bool
-		reportFmt      string
-		outPath        string
-		eventsFmt      string
-		quiet          bool
-		noColor        bool
-		cli            bool
-		tui            bool
-		failBelow      int
-		profile        string
-		configPath     string
-		minConfidence  string
-		signalSet      string
-		ciSystem       string
-		debug          bool
-		clock          string
-		includeSignal  []string
-		excludeSignal  []string
-		levelFilters   []int
-		familyFilters  []string
+		asJSON        bool
+		reportFmt     string
+		outPath       string
+		eventsFmt     string
+		quiet         bool
+		noColor       bool
+		cli           bool
+		tui           bool
+		failBelow     int
+		profile       string
+		configPath    string
+		minConfidence string
+		signalSet     string
+		ciSystem      string
+		debug         bool
+		clock         string
+		includeSignal []string
+		excludeSignal []string
+		levelFilters  []int
+		familyFilters []string
 	)
 
 	cmd := &cobra.Command{

--- a/cmd/plumbline/explain.go
+++ b/cmd/plumbline/explain.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+func newExplainCmd(stdout, stderr io.Writer) *cobra.Command {
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "explain <signal-id>",
+		Short: "Print a signal's description, detection rule, and rationale (no scan)",
+		Long: `plumbline explain — static description of a signal.
+
+Prints the signal's title, description, detection rule summary, and the
+rationale for why it matters at its level. Does not scan a repository;
+use 'plumbline inspect' for that.
+
+Examples:
+  plumbline explain l2.claude-md
+  plumbline explain l3.coverage-gate --json
+
+See also:
+  plumbline inspect <id>     run a scan and report this signal's status
+  plumbline signals          list every known signal`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			_ = asJSON
+			fmt.Fprintln(stderr, "(M1: explain is wired up; signals populate with the next PR.)")
+			return errCannotRun(errors.New("not implemented in this milestone"))
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the description as JSON.")
+	return cmd
+}

--- a/cmd/plumbline/help.go
+++ b/cmd/plumbline/help.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+// helpTopics is the registry of topical help pages. Bodies are stubbed
+// in this PR; each topic's prose lands in subsequent milestones (see
+// SPEC.md §9.5 topic catalog).
+var helpTopics = map[string]string{
+	"levels":        "(not implemented in this milestone) The five ACMM levels.",
+	"signals":       "(not implemented in this milestone) Signal lifecycle, status, partial-credit semantics.",
+	"scoring":       "(not implemented in this milestone) Threshold math, no-skip rule, next_gap.",
+	"output":        "(not implemented in this milestone) Every output mode with examples.",
+	"config":        "(not implemented in this milestone) The .plumbline.yml schema.",
+	"ci":            "(not implemented in this milestone) Wiring plumbline into CI; copy-pasteable YAML.",
+	"agents":        "(not implemented in this milestone) Recommended call sequences for LLM tool callers.",
+	"profiles":      "(not implemented in this milestone) Named signal presets.",
+	"compatibility": "(not implemented in this milestone) Signal-set versions and migration notes.",
+}
+
+func newHelpCmd(stdout io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "help [topic]",
+		Short: "Long-form help on a topic, or the topic index when called bare",
+		Long: `plumbline help — long-form, prose help for cross-cutting topics.
+
+Output is plain markdown so an LLM agent can ingest it directly. Each
+topic has a stable URL fragment (e.g. 'plumbline help scoring#no-skip-rule')
+that error messages can deep-link to.
+
+Without an argument, prints the topic index. With a topic, prints that
+topic's full text.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				printTopicIndex(stdout)
+				return nil
+			}
+			topic := args[0]
+			body, ok := helpTopics[topic]
+			if !ok {
+				return errCannotRun(fmt.Errorf("unknown topic: %q. Run 'plumbline help' for the list", topic))
+			}
+			fmt.Fprintln(stdout, body)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func printTopicIndex(w io.Writer) {
+	keys := make([]string, 0, len(helpTopics))
+	for k := range helpTopics {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	fmt.Fprintln(w, "plumbline help — topical guides")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Topics:")
+	for _, k := range keys {
+		fmt.Fprintf(w, "  plumbline help %s\n", k)
+	}
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Run 'plumbline <command> --help' for per-command flag reference.")
+}

--- a/cmd/plumbline/inspect.go
+++ b/cmd/plumbline/inspect.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+func newInspectCmd(stdout, stderr io.Writer) *cobra.Command {
+	var (
+		asJSON bool
+		debug  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "inspect <signal-id> [path]",
+		Short: "Run a scan and print the detail view for one signal",
+		Long: `plumbline inspect — run a scan and print the detail view for a single signal.
+
+CLI equivalent of opening the TUI's detail screen for that signal: shows
+the signal's status, score, confidence, evidence, and a fix recipe.
+
+Examples:
+  # Inspect why CLAUDE.md detection said what it said.
+  plumbline inspect l2.claude-md
+
+  # JSON for an LLM agent to parse.
+  plumbline inspect l3.coverage-gate --json
+
+  # Inspect a signal in a different repo.
+  plumbline inspect l2.pr-template /path/to/repo
+
+Exit codes:
+  0  signal detail printed
+  2  could not run (signal id unknown, path not a repo)
+  3  configuration error
+
+See also:
+  plumbline explain <id>     static description without scanning
+  plumbline signals          list every known signal id`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			_ = debug
+			fmt.Fprintln(stderr, "(M1: inspect is wired up; signal execution lands with the scanner.)")
+			fmt.Fprintln(stderr, "Hint: 'plumbline signals' will list ids once the registry is populated.")
+			return errCannotRun(errors.New("not implemented in this milestone"))
+		},
+	}
+
+	f := cmd.Flags()
+	f.BoolVar(&asJSON, "json", false, "Emit a single signal-result JSON object.")
+	f.BoolVar(&debug, "debug", false, "Include detection diagnostics in output.")
+	return cmd
+}

--- a/cmd/plumbline/main.go
+++ b/cmd/plumbline/main.go
@@ -34,9 +34,9 @@ type exitError struct {
 func (e *exitError) Error() string { return e.err.Error() }
 func (e *exitError) Unwrap() error { return e.err }
 
-func errCannotRun(err error) error      { return &exitError{exitCannotRun, err} }
-func errConfigError(err error) error    { return &exitError{exitConfigError, err} } //nolint:unused // wired in M1
-func errInternalError(err error) error  { return &exitError{exitInternalErrror, err} } //nolint:unused
+func errCannotRun(err error) error     { return &exitError{exitCannotRun, err} }
+func errConfigError(err error) error   { return &exitError{exitConfigError, err} }    //nolint:unused // wired in M1
+func errInternalError(err error) error { return &exitError{exitInternalErrror, err} } //nolint:unused
 
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))

--- a/cmd/plumbline/main.go
+++ b/cmd/plumbline/main.go
@@ -1,0 +1,99 @@
+// Command plumbline is a repo-level AI coding readiness assessment tool.
+//
+// See SPEC.md at the repo root for the full design. The CLI is the
+// primary surface; the Bubble Tea TUI is a peer interface that lands
+// in milestone M2.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Exit codes are part of the public CLI contract — see SPEC.md §4.
+const (
+	exitOK             = 0
+	exitGateFailed     = 1
+	exitCannotRun      = 2
+	exitConfigError    = 3
+	exitInternalErrror = 4
+)
+
+// exitError lets a subcommand return an error annotated with the exit
+// code that should be reported to the shell. Anything that is not an
+// exitError gets mapped to exitInternalErrror.
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+func (e *exitError) Unwrap() error { return e.err }
+
+func errCannotRun(err error) error      { return &exitError{exitCannotRun, err} }
+func errConfigError(err error) error    { return &exitError{exitConfigError, err} } //nolint:unused // wired in M1
+func errInternalError(err error) error  { return &exitError{exitInternalErrror, err} } //nolint:unused
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run executes the CLI with the given args and returns an exit code.
+// Split out from main() so tests can drive it with synthetic args.
+func run(args []string, stdout, stderr io.Writer) int {
+	root := newRootCmd(stdout, stderr)
+	root.SetArgs(args)
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+
+	err := root.Execute()
+	if err == nil {
+		return exitOK
+	}
+	var ee *exitError
+	if errors.As(err, &ee) {
+		fmt.Fprintf(stderr, "error: %s\n", ee.err.Error())
+		return ee.code
+	}
+	// Unknown command, bad flag, or unannotated subcommand error —
+	// SilenceErrors keeps cobra quiet, so we print it ourselves.
+	fmt.Fprintf(stderr, "error: %s\n", err.Error())
+	return exitConfigError
+}
+
+func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
+	root := &cobra.Command{
+		Use:   "plumbline",
+		Short: "Repo-level AI coding readiness assessment based on the ACMM",
+		Long: `plumbline assesses a repository's AI Codebase Maturity Model (ACMM) level
+by detecting feedback-loop artifacts on disk. It runs deterministic checks —
+no LLM calls, no network — and reports which loops exist, which are missing,
+and what to add to reach the next level.
+
+Two interfaces at full feature parity:
+  • Interactive TUI (Bubble Tea) — default when stdout is a TTY
+  • Pure CLI — flag-driven, for LLM tool callers and CI gates
+
+Run 'plumbline help' for topical guides, or '<command> --help' for flags.`,
+		SilenceUsage:  true, // don't dump usage on every error
+		SilenceErrors: true, // we print errors ourselves with the right stream
+	}
+
+	// Replace cobra's built-in `help` command with our topic-help command.
+	root.SetHelpCommand(newHelpCmd(stdout))
+
+	root.AddCommand(
+		newAssessCmd(stdout, stderr),
+		newInspectCmd(stdout, stderr),
+		newSignalsCmd(stdout, stderr),
+		newExplainCmd(stdout, stderr),
+		newSchemaCmd(stdout, stderr),
+		newVersionCmd(stdout),
+	)
+
+	return root
+}

--- a/cmd/plumbline/main_test.go
+++ b/cmd/plumbline/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// runCLI is a test helper that invokes the CLI in-process.
+func runCLI(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := run(args, &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+func TestRoot_NoArgsShowsHelp(t *testing.T) {
+	code, out, _ := runCLI(t)
+	if code != exitOK {
+		t.Fatalf("expected exit %d, got %d", exitOK, code)
+	}
+	if !strings.Contains(out, "plumbline assesses") {
+		t.Errorf("root help missing long-description marker; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Available Commands") {
+		t.Errorf("root help missing command list; got:\n%s", out)
+	}
+}
+
+func TestVersion_PlainText(t *testing.T) {
+	code, out, _ := runCLI(t, "version")
+	if code != exitOK {
+		t.Fatalf("expected exit %d, got %d", exitOK, code)
+	}
+	if !strings.Contains(out, "plumbline ") {
+		t.Errorf("expected version banner, got:\n%s", out)
+	}
+	if !strings.Contains(out, "signal-set: v1") {
+		t.Errorf("expected signal-set version line, got:\n%s", out)
+	}
+}
+
+func TestVersion_JSON(t *testing.T) {
+	code, out, _ := runCLI(t, "version", "--json")
+	if code != exitOK {
+		t.Fatalf("expected exit %d, got %d", exitOK, code)
+	}
+	if !strings.Contains(out, `"signal_set_version": "v1"`) {
+		t.Errorf("expected signal_set_version field in JSON, got:\n%s", out)
+	}
+}
+
+func TestHelp_TopicIndex(t *testing.T) {
+	code, out, _ := runCLI(t, "help")
+	if code != exitOK {
+		t.Fatalf("expected exit %d, got %d", exitOK, code)
+	}
+	for _, topic := range []string{"levels", "signals", "scoring", "agents", "compatibility"} {
+		if !strings.Contains(out, "plumbline help "+topic) {
+			t.Errorf("help index missing topic %q; got:\n%s", topic, out)
+		}
+	}
+}
+
+func TestHelp_UnknownTopic(t *testing.T) {
+	code, _, errOut := runCLI(t, "help", "made-up-topic")
+	if code != exitCannotRun {
+		t.Fatalf("expected exit %d for unknown topic, got %d (stderr: %s)", exitCannotRun, code, errOut)
+	}
+	if !strings.Contains(errOut, "unknown topic") {
+		t.Errorf("expected 'unknown topic' in stderr, got:\n%s", errOut)
+	}
+}
+
+// TestStubs_ReportNotImplemented ensures every stub command currently
+// reports a clean exit code rather than panicking. When real logic
+// lands, these tests will be replaced with behavior tests.
+func TestStubs_ReportNotImplemented(t *testing.T) {
+	cases := [][]string{
+		{"assess"},
+		{"inspect", "l2.claude-md"},
+		{"signals"},
+		{"explain", "l2.claude-md"},
+		{"schema", "verdict"},
+	}
+	for _, args := range cases {
+		args := args
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			code, _, errOut := runCLI(t, args...)
+			if code != exitCannotRun {
+				t.Errorf("expected exit %d (cannot run / not implemented), got %d", exitCannotRun, code)
+			}
+			if !strings.Contains(errOut, "not implemented") {
+				t.Errorf("expected 'not implemented' marker in stderr, got:\n%s", errOut)
+			}
+		})
+	}
+}
+
+// TestAssess_FlagValidation checks the cross-flag rules that hold
+// independent of milestone (mutually exclusive --cli/--tui, etc.).
+func TestAssess_FlagValidation(t *testing.T) {
+	code, _, errOut := runCLI(t, "assess", "--cli", "--tui")
+	if code != exitCannotRun {
+		t.Errorf("expected exit %d, got %d (stderr: %s)", exitCannotRun, code, errOut)
+	}
+	if !strings.Contains(errOut, "mutually exclusive") {
+		t.Errorf("expected 'mutually exclusive' in stderr, got:\n%s", errOut)
+	}
+}
+
+func TestUnknownCommand_ExitsConfigError(t *testing.T) {
+	code, _, _ := runCLI(t, "definitely-not-a-command")
+	if code != exitConfigError {
+		t.Errorf("expected exit %d for unknown command, got %d", exitConfigError, code)
+	}
+}

--- a/cmd/plumbline/schema.go
+++ b/cmd/plumbline/schema.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// schemaNames is the set of public output types whose JSON Schemas
+// plumbline publishes. See SPEC.md §9.5.
+var schemaNames = []string{"verdict", "signal-result", "event", "config"}
+
+func newSchemaCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "schema <name>",
+		Short: "Emit the JSON Schema for a public output type",
+		Long: `plumbline schema — emit the JSON Schema for a named output type.
+
+Schemas are draft-2020-12. Their $id includes the major version
+(plumbline/v1/...). Backwards-incompatible changes bump the major and
+ship a deprecation alias for one minor version.
+
+Available names:
+  verdict         top-level result of 'assess --json'
+  signal-result   one signal's entry within a verdict (also 'inspect --json')
+  event           NDJSON event line emitted by '--events ndjson'
+  config          .plumbline.yml schema
+
+Examples:
+  plumbline schema verdict
+  plumbline schema event > event.schema.json
+
+See also:
+  plumbline help compatibility   when schemas change between versions
+  plumbline help agents          schema-fetching workflow for tool callers`,
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: schemaNames,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			fmt.Fprintf(stderr, "(M1: schema %q recognized; publishing lands with the JSON output PR.)\n", name)
+			return errCannotRun(errors.New("not implemented in this milestone"))
+		},
+	}
+	return cmd
+}

--- a/cmd/plumbline/signals.go
+++ b/cmd/plumbline/signals.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+func newSignalsCmd(stdout, stderr io.Writer) *cobra.Command {
+	var (
+		asJSON       bool
+		levelFilters []int
+		familyFilter []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "signals",
+		Short: "List every signal the tool knows how to detect",
+		Long: `plumbline signals — list every signal the tool knows how to detect.
+
+Static — does not scan a repo. Filterable by ACMM level and family. The
+JSON output is the canonical way for an LLM agent to discover what's
+detectable before calling 'assess'.
+
+Examples:
+  # All signals, grouped by level.
+  plumbline signals
+
+  # Only L3 signals in the coverage family.
+  plumbline signals --level 3 --family coverage
+
+  # Machine-readable for tool callers.
+  plumbline signals --json
+
+See also:
+  plumbline explain <id>     long-form description of one signal
+  plumbline help signals     signal lifecycle and partial-credit semantics`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			_ = asJSON
+			_ = levelFilters
+			_ = familyFilter
+			fmt.Fprintln(stderr, "(M1: signals is wired up; the registry populates with the next PR.)")
+			return errCannotRun(errors.New("not implemented in this milestone"))
+		},
+	}
+
+	f := cmd.Flags()
+	f.BoolVar(&asJSON, "json", false, "Emit the registry as JSON to stdout.")
+	f.IntSliceVar(&levelFilters, "level", nil, "Only list signals at level N (2-5). Repeatable.")
+	f.StringSliceVar(&familyFilter, "family", nil, "Only list signals in family <name>. Repeatable.")
+	return cmd
+}

--- a/cmd/plumbline/version.go
+++ b/cmd/plumbline/version.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sroberts/plumbline/internal/buildinfo"
+)
+
+func newVersionCmd(stdout io.Writer) *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print build version, commit, and signal-set version",
+		Long: `Prints plumbline's build version and the signal-set version it ships.
+
+The signal-set version is what CI gates pin via 'assess --signal-set vN'.
+See 'plumbline help compatibility' for the policy.
+
+Examples:
+  plumbline version
+  plumbline version --json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			info := struct {
+				Version          string `json:"version"`
+				Commit           string `json:"commit"`
+				SignalSetVersion string `json:"signal_set_version"`
+				Schema           string `json:"schema"`
+			}{
+				Version:          buildinfo.Version,
+				Commit:           buildinfo.Commit,
+				SignalSetVersion: buildinfo.SignalSetVersion,
+				Schema:           buildinfo.Schema,
+			}
+			if asJSON {
+				enc := json.NewEncoder(stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(info)
+			}
+			fmt.Fprintf(stdout, "plumbline %s (%s)\nsignal-set: %s\nschema: %s\n",
+				info.Version, info.Commit, info.SignalSetVersion, info.Schema)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit JSON to stdout.")
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/sroberts/plumbline
+
+go 1.26.1
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,14 @@
+// Package buildinfo holds release metadata injected at build time via -ldflags.
+package buildinfo
+
+var (
+	Version = "dev"
+	Commit  = "unknown"
+)
+
+// SignalSetVersion is the current frozen signal-set version. Bumping this
+// is governed by the SPEC.md §7 compatibility policy.
+const SignalSetVersion = "v1"
+
+// Schema is the top-level $id prefix for published JSON Schemas.
+const Schema = "plumbline/v1"

--- a/pkg/acmm/types.go
+++ b/pkg/acmm/types.go
@@ -154,11 +154,11 @@ type SignalResult struct {
 // Verdict is the top-level result of an `assess` run. Its shape is the
 // `verdict` schema published via `plumbline schema verdict`.
 type Verdict struct {
-	Level                Level           `json:"level"`
-	Name                 string          `json:"name"`
+	Level                Level             `json:"level"`
+	Name                 string            `json:"name"`
 	LevelScores          map[Level]float64 `json:"level_scores"`
-	NextGap              []string        `json:"next_gap"`
-	MinConfidenceApplied Confidence      `json:"min_confidence_applied"`
+	NextGap              []string          `json:"next_gap"`
+	MinConfidenceApplied Confidence        `json:"min_confidence_applied"`
 }
 
 // Report is the top-level JSON document emitted by `assess --json`.

--- a/pkg/acmm/types.go
+++ b/pkg/acmm/types.go
@@ -1,0 +1,174 @@
+// Package acmm holds the public types for plumbline's ACMM assessor.
+//
+// These types are the API surface consumed by --json output, the JSON
+// schemas published via `plumbline schema`, and any external tools that
+// parse plumbline results. Backwards-incompatible changes here require
+// a major version bump of the schema $id (see SPEC.md §7 signal-set
+// versioning and §9.5 schema contract tests).
+package acmm
+
+// Level is an ACMM maturity level (1–5). Level 1 is the implicit floor
+// — every repo has it. Levels 2–5 each correspond to a feedback-loop
+// topology described in the source paper.
+type Level int
+
+const (
+	LevelAssisted       Level = 1
+	LevelInstructed     Level = 2
+	LevelMeasured       Level = 3
+	LevelAdaptive       Level = 4
+	LevelSelfSustaining Level = 5
+)
+
+// Name returns the human-readable name of the level.
+func (l Level) Name() string {
+	switch l {
+	case LevelAssisted:
+		return "Assisted"
+	case LevelInstructed:
+		return "Instructed"
+	case LevelMeasured:
+		return "Measured"
+	case LevelAdaptive:
+		return "Adaptive"
+	case LevelSelfSustaining:
+		return "Self-Sustaining"
+	default:
+		return "Unknown"
+	}
+}
+
+// Status is the qualitative result of running a single signal against
+// a repository. Status is derived from Score per the rubric; signals
+// do not set Status directly.
+type Status string
+
+const (
+	StatusFound   Status = "found"
+	StatusPartial Status = "partial"
+	StatusMissing Status = "missing"
+	StatusNA      Status = "na"
+)
+
+// Score values from the mandatory four-step partial-credit rubric.
+// See SPEC.md §6.
+const (
+	ScoreMissing    = 0.0  // artifact absent
+	ScoreStubbed    = 0.33 // named or stubbed only
+	ScoreIncomplete = 0.67 // present but incomplete
+	ScoreFound      = 1.0  // fully wired
+)
+
+// StatusFromScore maps the rubric score onto a Status. Any score not
+// equal to one of the four rubric values is treated as Partial; signal
+// authors are expected to use only the rubric values.
+func StatusFromScore(score float64) Status {
+	switch score {
+	case ScoreMissing:
+		return StatusMissing
+	case ScoreFound:
+		return StatusFound
+	default:
+		return StatusPartial
+	}
+}
+
+// Confidence is independent of Score and answers a different question:
+// how trustworthy is this verdict? See SPEC.md §6 confidence ladder.
+type Confidence string
+
+const (
+	ConfidenceHigh   Confidence = "high"
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceLow    Confidence = "low"
+)
+
+// AtLeast reports whether c is at or above the named minimum.
+func (c Confidence) AtLeast(min Confidence) bool {
+	rank := map[Confidence]int{ConfidenceLow: 0, ConfidenceMedium: 1, ConfidenceHigh: 2}
+	return rank[c] >= rank[min]
+}
+
+// Method describes how a signal arrived at its result. The verdict
+// JSON exposes this so a CI gate can reason about strictness without
+// reading evidence.
+type Method string
+
+const (
+	MethodFilenameMatch Method = "filename"
+	MethodContentRegex  Method = "content-regex"
+	MethodAST           Method = "ast"
+	MethodCrossFile     Method = "cross-file"
+)
+
+// LineSpan is an optional location within a file used by Evidence.
+type LineSpan struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+// Evidence is a citation produced by a signal — the path, optional
+// line range, and an excerpt the user can verify by hand.
+type Evidence struct {
+	Path    string    `json:"path"`
+	Span    *LineSpan `json:"span,omitempty"`
+	Excerpt string    `json:"excerpt,omitempty"`
+}
+
+// DiagEntry is one line of detection diagnostics, populated only when
+// --debug is set. See SPEC.md §8.2.7.
+type DiagEntry struct {
+	Path   string `json:"path"`
+	Action string `json:"action"`
+	Hit    bool   `json:"hit"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// Result is what every signal returns. Score must come from the rubric
+// constants above; Status is derived from Score.
+type Result struct {
+	Status     Status      `json:"status"`
+	Score      float64     `json:"score"`
+	Confidence Confidence  `json:"confidence"`
+	Method     Method      `json:"method"`
+	Evidence   []Evidence  `json:"evidence,omitempty"`
+	Notes      []string    `json:"notes,omitempty"`
+	Diag       []DiagEntry `json:"diag,omitempty"`
+}
+
+// SignalResult is one signal's entry within a verdict.
+type SignalResult struct {
+	ID         string      `json:"id"`
+	Level      Level       `json:"level"`
+	Family     string      `json:"family"`
+	Title      string      `json:"title,omitempty"`
+	Status     Status      `json:"status"`
+	Score      float64     `json:"score"`
+	Confidence Confidence  `json:"confidence"`
+	Method     Method      `json:"method"`
+	Evidence   []Evidence  `json:"evidence,omitempty"`
+	Notes      []string    `json:"notes,omitempty"`
+	Diag       []DiagEntry `json:"diag,omitempty"`
+}
+
+// Verdict is the top-level result of an `assess` run. Its shape is the
+// `verdict` schema published via `plumbline schema verdict`.
+type Verdict struct {
+	Level                Level           `json:"level"`
+	Name                 string          `json:"name"`
+	LevelScores          map[Level]float64 `json:"level_scores"`
+	NextGap              []string        `json:"next_gap"`
+	MinConfidenceApplied Confidence      `json:"min_confidence_applied"`
+}
+
+// Report is the top-level JSON document emitted by `assess --json`.
+type Report struct {
+	Schema           string         `json:"schema"`
+	ToolVersion      string         `json:"tool_version"`
+	SignalSetVersion string         `json:"signal_set_version"`
+	CISystem         string         `json:"ci_system"`
+	Repo             string         `json:"repo"`
+	ScannedAt        string         `json:"scanned_at"`
+	Verdict          Verdict        `json:"verdict"`
+	Signals          []SignalResult `json:"signals"`
+}

--- a/pkg/acmm/types_test.go
+++ b/pkg/acmm/types_test.go
@@ -1,0 +1,62 @@
+package acmm
+
+import "testing"
+
+func TestStatusFromScore(t *testing.T) {
+	cases := []struct {
+		score float64
+		want  Status
+	}{
+		{ScoreMissing, StatusMissing},
+		{ScoreStubbed, StatusPartial},
+		{ScoreIncomplete, StatusPartial},
+		{ScoreFound, StatusFound},
+		{0.5, StatusPartial},
+	}
+	for _, c := range cases {
+		if got := StatusFromScore(c.score); got != c.want {
+			t.Errorf("StatusFromScore(%v) = %q, want %q", c.score, got, c.want)
+		}
+	}
+}
+
+func TestConfidenceAtLeast(t *testing.T) {
+	cases := []struct {
+		got, min Confidence
+		want     bool
+	}{
+		{ConfidenceHigh, ConfidenceHigh, true},
+		{ConfidenceHigh, ConfidenceMedium, true},
+		{ConfidenceHigh, ConfidenceLow, true},
+		{ConfidenceMedium, ConfidenceHigh, false},
+		{ConfidenceMedium, ConfidenceMedium, true},
+		{ConfidenceMedium, ConfidenceLow, true},
+		{ConfidenceLow, ConfidenceHigh, false},
+		{ConfidenceLow, ConfidenceMedium, false},
+		{ConfidenceLow, ConfidenceLow, true},
+	}
+	for _, c := range cases {
+		if got := c.got.AtLeast(c.min); got != c.want {
+			t.Errorf("Confidence(%q).AtLeast(%q) = %v, want %v", c.got, c.min, got, c.want)
+		}
+	}
+}
+
+func TestLevelName(t *testing.T) {
+	cases := []struct {
+		l    Level
+		want string
+	}{
+		{LevelAssisted, "Assisted"},
+		{LevelInstructed, "Instructed"},
+		{LevelMeasured, "Measured"},
+		{LevelAdaptive, "Adaptive"},
+		{LevelSelfSustaining, "Self-Sustaining"},
+		{Level(99), "Unknown"},
+	}
+	for _, c := range cases {
+		if got := c.l.Name(); got != c.want {
+			t.Errorf("Level(%d).Name() = %q, want %q", c.l, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `pkg/acmm` public types: `Level`, `Status`, `Confidence`, `Method`, `Result`, `SignalResult`, `Verdict`, `Report`. Includes the four-step partial-credit rubric constants (`ScoreMissing` / `ScoreStubbed` / `ScoreIncomplete` / `ScoreFound`) and a `StatusFromScore` mapper so `Status` is always derived from `Score`.
- `cmd/plumbline` cobra root with `assess` / `inspect` / `signals` / `explain` / `schema` / `help` / `version` subcommands. `version` and `help` (topic index) actually work; the rest are intentional stubs that exit `2` with `error: not implemented in this milestone`. Topic-help replaces cobra's built-in `help` command.
- `internal/buildinfo` with ldflag-injectable `Version` / `Commit` and the frozen `SignalSetVersion = "v1"`.
- Each subcommand carries the descriptive `--help` text required by SPEC.md §9.5; `assess` wires up the full flag surface from §4 (`--cli`, `--tui`, `--json`, `--events`, `--min-confidence`, `--signal-set`, `--ci-system`, `--debug`, `--clock`, etc.).

Detection logic, the scanner, and the signal registry land in the next PR.

## Test plan
- [ ] \`make build && ./plumbline version\` prints version, signal-set, schema
- [ ] \`./plumbline help\` lists the topic index
- [ ] \`./plumbline assess --help\` matches SPEC.md §9.5 (synopsis, description, flags, examples, exit codes, see-also)
- [ ] \`./plumbline assess --cli --tui\` exits non-zero with \"mutually exclusive\"
- [ ] \`make test\` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)