### PR TITLE
Vertical slice: scanner + signal registry + l2.claude-md + scoring + assess --json

### DIFF
--- a/cmd/plumbline/assess.go
+++ b/cmd/plumbline/assess.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/sroberts/plumbline/internal/buildinfo"
+	"github.com/sroberts/plumbline/internal/scanner"
+	"github.com/sroberts/plumbline/internal/scoring"
+	"github.com/sroberts/plumbline/internal/signals"
+	"github.com/sroberts/plumbline/pkg/acmm"
 )
 
 func newAssessCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -73,17 +83,42 @@ See also:
   plumbline help agents      guidance for LLM tool callers`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_ = args
-			// Cross-flag validation that's true regardless of milestone.
 			if cli && tui {
 				return errCannotRun(errors.New("--cli and --tui are mutually exclusive"))
 			}
 			if len(includeSignal) > 0 && len(excludeSignal) > 0 {
 				return errCannotRun(errors.New("--include-signal and --exclude-signal are mutually exclusive"))
 			}
-			fmt.Fprintln(stderr, "(M1: assess is wired up but the scanner and signals land in the next PR)")
-			fmt.Fprintln(stderr, "Hint: run 'plumbline help' for the topic index.")
-			return errCannotRun(errors.New("not implemented in this milestone"))
+
+			path := "."
+			if len(args) == 1 {
+				path = args[0]
+			}
+
+			confLevel, err := parseConfidence(minConfidence)
+			if err != nil {
+				return errCannotRun(err)
+			}
+
+			report, err := runAssess(cmd.Context(), path, scoring.Options{MinConfidence: confLevel})
+			if err != nil {
+				return errCannotRun(err)
+			}
+
+			if asJSON {
+				enc := json.NewEncoder(stdout)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(report); err != nil {
+					return errCannotRun(err)
+				}
+				return nil
+			}
+
+			// Default human-readable text. Fuller layout (level bars,
+			// next-gap panel) lands in the next PR; for now keep it
+			// short so something useful prints in non-JSON mode.
+			writeBriefText(stdout, report)
+			return nil
 		},
 	}
 
@@ -110,4 +145,92 @@ See also:
 	f.StringSliceVar(&familyFilters, "family", nil, "Only run signals in family <name>. Repeatable.")
 
 	return cmd
+}
+
+// runAssess executes the scan -> detect -> score pipeline and returns
+// a populated Report. Pulled out of RunE so it stays testable in
+// isolation when more flags arrive (filters, profiles, --enrich, etc.).
+func runAssess(ctx context.Context, path string, opts scoring.Options) (acmm.Report, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return acmm.Report{}, err
+	}
+
+	idx, err := scanner.Scan(abs)
+	if err != nil {
+		return acmm.Report{}, err
+	}
+
+	registered := signals.Default.All()
+	results := make([]acmm.SignalResult, 0, len(registered))
+	for _, s := range registered {
+		r := s.Detect(ctx, idx)
+		results = append(results, acmm.SignalResult{
+			ID:         s.ID(),
+			Level:      s.Level(),
+			Family:     s.Family(),
+			Title:      s.Title(),
+			Status:     r.Status,
+			Score:      r.Score,
+			Confidence: r.Confidence,
+			Method:     r.Method,
+			Evidence:   r.Evidence,
+			Notes:      r.Notes,
+			Diag:       r.Diag,
+		})
+	}
+
+	verdict := scoring.Compute(results, opts)
+
+	return acmm.Report{
+		Schema:           buildinfo.Schema,
+		ToolVersion:      buildinfo.Version,
+		SignalSetVersion: buildinfo.SignalSetVersion,
+		CISystem:         "github-actions",
+		Repo:             abs,
+		ScannedAt:        time.Now().UTC().Format(time.RFC3339),
+		Verdict:          verdict,
+		Signals:          results,
+	}, nil
+}
+
+func parseConfidence(s string) (acmm.Confidence, error) {
+	switch s {
+	case "", "low":
+		return acmm.ConfidenceLow, nil
+	case "medium":
+		return acmm.ConfidenceMedium, nil
+	case "high":
+		return acmm.ConfidenceHigh, nil
+	default:
+		return "", fmt.Errorf("invalid --min-confidence %q (want low|medium|high)", s)
+	}
+}
+
+// writeBriefText prints a one-screen summary of the verdict. The richer
+// layout (level bars, next-gap panel) lands in a follow-up PR.
+func writeBriefText(w io.Writer, r acmm.Report) {
+	fmt.Fprintf(w, "plumbline · %s\n", r.Repo)
+	fmt.Fprintf(w, "Assessed level: %d (%s)\n\n", r.Verdict.Level, r.Verdict.Name)
+	for _, l := range []acmm.Level{
+		acmm.LevelInstructed,
+		acmm.LevelMeasured,
+		acmm.LevelAdaptive,
+		acmm.LevelSelfSustaining,
+	} {
+		fmt.Fprintf(w, "  L%d %-16s  %5.1f%%\n", l, l.Name(), r.Verdict.LevelScores[l]*100)
+	}
+	if len(r.Verdict.NextGap) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Next-level gap (to reach L%d):\n", r.Verdict.Level+1)
+		for _, id := range r.Verdict.NextGap {
+			fmt.Fprintf(w, "  · %s\n", id)
+		}
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Hint: re-run with --json for machine-readable output.")
 }

--- a/cmd/plumbline/assess_test.go
+++ b/cmd/plumbline/assess_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// writeFile is a small helper to write a file at <dir>/<rel>.
+func writeFile(t *testing.T, dir, rel, body string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// substantiveClaudeMD is a CLAUDE.md body that satisfies the L2 signal
+// (heading + ≥30 non-blank lines).
+func substantiveClaudeMD() string {
+	body := "# CLAUDE.md\n\n"
+	body += strings.Repeat("Some real, non-blank line of guidance.\n", 35)
+	return body
+}
+
+func TestAssessJSON_FoundClaudeMDReachesLevelTwo(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CLAUDE.md", substantiveClaudeMD())
+
+	code, out, errOut := runCLI(t, "assess", "--json", dir)
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (stderr: %s)", code, exitOK, errOut)
+	}
+
+	var report acmm.Report
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("unmarshal: %v\nstdout: %s", err, out)
+	}
+
+	if report.Schema != "plumbline/v1" {
+		t.Errorf("schema = %q, want plumbline/v1", report.Schema)
+	}
+	if report.SignalSetVersion != "v1" {
+		t.Errorf("signal_set_version = %q, want v1", report.SignalSetVersion)
+	}
+	if report.Verdict.Level != acmm.LevelInstructed {
+		t.Errorf("Verdict.Level = %d, want 2 (Instructed) for substantive CLAUDE.md", report.Verdict.Level)
+	}
+	if len(report.Signals) == 0 {
+		t.Fatal("Signals is empty")
+	}
+
+	var got *acmm.SignalResult
+	for i := range report.Signals {
+		if report.Signals[i].ID == "l2.claude-md" {
+			got = &report.Signals[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("l2.claude-md not in signals; ids=%v", signalIDs(report.Signals))
+	}
+	if got.Status != acmm.StatusFound {
+		t.Errorf("l2.claude-md status = %q, want found", got.Status)
+	}
+	if got.Score != acmm.ScoreFound {
+		t.Errorf("l2.claude-md score = %v, want %v", got.Score, acmm.ScoreFound)
+	}
+}
+
+func TestAssessJSON_MissingClaudeMDStaysAtLevelOne(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "README.md", "# repo\n")
+
+	code, out, errOut := runCLI(t, "assess", "--json", dir)
+	if code != exitOK {
+		t.Fatalf("exit = %d, want %d (stderr: %s)", code, exitOK, errOut)
+	}
+
+	var report acmm.Report
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("unmarshal: %v\nstdout: %s", err, out)
+	}
+
+	if report.Verdict.Level != acmm.LevelAssisted {
+		t.Errorf("Verdict.Level = %d, want 1 (Assisted) when CLAUDE.md is missing", report.Verdict.Level)
+	}
+	// next_gap should call out the missing signal at L+1 (=L2).
+	found := false
+	for _, id := range report.Verdict.NextGap {
+		if id == "l2.claude-md" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("next_gap missing 'l2.claude-md'; got %v", report.Verdict.NextGap)
+	}
+}
+
+func TestAssessJSON_BadPathExitsCannotRun(t *testing.T) {
+	code, _, errOut := runCLI(t, "assess", "--json", "/definitely/does/not/exist/12345")
+	if code != exitCannotRun {
+		t.Errorf("exit = %d, want %d (cannot run)", code, exitCannotRun)
+	}
+	if !strings.Contains(errOut, "error:") {
+		t.Errorf("expected an 'error:' line in stderr, got: %s", errOut)
+	}
+}
+
+func signalIDs(sigs []acmm.SignalResult) []string {
+	out := make([]string, len(sigs))
+	for i, s := range sigs {
+		out[i] = s.ID
+	}
+	return out
+}

--- a/cmd/plumbline/main_test.go
+++ b/cmd/plumbline/main_test.go
@@ -72,12 +72,12 @@ func TestHelp_UnknownTopic(t *testing.T) {
 	}
 }
 
-// TestStubs_ReportNotImplemented ensures every stub command currently
-// reports a clean exit code rather than panicking. When real logic
-// lands, these tests will be replaced with behavior tests.
+// TestStubs_ReportNotImplemented ensures every still-stub command
+// reports a clean exit code rather than panicking. As real logic lands
+// for each command, its entry drops out of this list and migrates to a
+// behavior test (see assess_test.go for the assess equivalent).
 func TestStubs_ReportNotImplemented(t *testing.T) {
 	cases := [][]string{
-		{"assess"},
 		{"inspect", "l2.claude-md"},
 		{"signals"},
 		{"explain", "l2.claude-md"},

--- a/cmd/plumbline/registrations.go
+++ b/cmd/plumbline/registrations.go
@@ -1,0 +1,8 @@
+package main
+
+// Blank-imports of signal packages so their init() functions register
+// detectors into signals.Default. As new level packages land (l3, l4,
+// l5), add them here.
+import (
+	_ "github.com/sroberts/plumbline/internal/signals/l2"
+)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,137 @@
+// Package scanner walks a repository and produces a RepoIndex that
+// signal detectors consume. The index carries metadata only; content is
+// reachable via idx.Read, which enforces the sample-size cap. See
+// SPEC.md §5 for the access contract.
+package scanner
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+)
+
+// ReadSampleSize is the maximum number of bytes idx.Read returns for any
+// single file. Files larger than this are sampled (first ReadSampleSize
+// bytes only), bounding memory and IO. See SPEC.md §11.
+const ReadSampleSize = 64 * 1024
+
+// defaultIgnoredDirs is the set of directory names skipped during a
+// scan unless the caller's config overrides them.
+var defaultIgnoredDirs = map[string]struct{}{
+	".git":         {},
+	"node_modules": {},
+	"vendor":       {},
+}
+
+// FileEntry is a metadata-only record of a tracked file. Content is
+// reachable via RepoIndex.Read.
+type FileEntry struct {
+	Path string
+	Size int64
+	Mode fs.FileMode
+}
+
+// WorkflowFile is a placeholder for the parsed CI workflow AST. The
+// scanner emits these once workflow parsing lands; for now the slice
+// is always empty.
+type WorkflowFile struct {
+	Path string
+}
+
+// RepoIndex is the metadata-only view of a repository, handed to every
+// signal detector. Its access contract is enforced by lint (signals are
+// forbidden from doing direct IO) and documented in SPEC.md §5.
+type RepoIndex struct {
+	Root      string
+	Files     []FileEntry
+	ByName    map[string][]string
+	Workflows []WorkflowFile
+	HasGit    bool
+
+	fsys  fs.FS
+	cache map[string][]byte
+}
+
+// Scan walks the repository at the given filesystem path and returns a
+// populated RepoIndex.
+func Scan(root string) (*RepoIndex, error) {
+	return scanFS(os.DirFS(root), root)
+}
+
+// scanFS is the testable core. Tests pass an fstest.MapFS; Scan wraps
+// it with os.DirFS for the real filesystem.
+func scanFS(fsys fs.FS, root string) (*RepoIndex, error) {
+	idx := &RepoIndex{
+		Root:   root,
+		ByName: make(map[string][]string),
+		fsys:   fsys,
+		cache:  make(map[string][]byte),
+	}
+
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == "." {
+			return nil
+		}
+
+		// Note .git presence even though its contents aren't indexed.
+		if p == ".git" {
+			idx.HasGit = true
+		}
+
+		if d.IsDir() {
+			if _, skip := defaultIgnoredDirs[p]; skip {
+				return fs.SkipDir
+			}
+			// Nested directories of the same name (e.g. project/vendor)
+			// are also skipped.
+			if _, skip := defaultIgnoredDirs[path.Base(p)]; skip {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		idx.Files = append(idx.Files, FileEntry{
+			Path: p,
+			Size: info.Size(),
+			Mode: info.Mode(),
+		})
+		base := path.Base(p)
+		idx.ByName[base] = append(idx.ByName[base], p)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return idx, nil
+}
+
+// Read returns up to ReadSampleSize bytes of the named tracked file.
+// Results are cached for the duration of the scan. Read is the only
+// sanctioned IO chokepoint for signal detectors.
+func (idx *RepoIndex) Read(p string) ([]byte, error) {
+	if cached, ok := idx.cache[p]; ok {
+		return cached, nil
+	}
+	f, err := idx.fsys.Open(p)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, io.LimitReader(f, ReadSampleSize)); err != nil {
+		return nil, err
+	}
+	data := buf.Bytes()
+	idx.cache[p] = data
+	return data, nil
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -57,12 +57,12 @@ type RepoIndex struct {
 // Scan walks the repository at the given filesystem path and returns a
 // populated RepoIndex.
 func Scan(root string) (*RepoIndex, error) {
-	return scanFS(os.DirFS(root), root)
+	return ScanFS(os.DirFS(root), root)
 }
 
-// scanFS is the testable core. Tests pass an fstest.MapFS; Scan wraps
+// ScanFS is the testable core. Tests pass an fstest.MapFS; Scan wraps
 // it with os.DirFS for the real filesystem.
-func scanFS(fsys fs.FS, root string) (*RepoIndex, error) {
+func ScanFS(fsys fs.FS, root string) (*RepoIndex, error) {
 	idx := &RepoIndex{
 		Root:   root,
 		ByName: make(map[string][]string),

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -26,9 +26,9 @@ func TestScan_IndexesAllNonIgnoredFiles(t *testing.T) {
 		"docs/intro.md": {Data: []byte("# intro")},
 	}
 
-	idx, err := scanFS(fsys, "/repo")
+	idx, err := ScanFS(fsys, "/repo")
 	if err != nil {
-		t.Fatalf("scanFS: %v", err)
+		t.Fatalf("ScanFS: %v", err)
 	}
 	if idx.Root != "/repo" {
 		t.Errorf("Root = %q, want %q", idx.Root, "/repo")
@@ -51,9 +51,9 @@ func TestScan_IgnoresDefaultPaths(t *testing.T) {
 		"src/main.go":           {Data: []byte("package main")},
 	}
 
-	idx, err := scanFS(fsys, ".")
+	idx, err := ScanFS(fsys, ".")
 	if err != nil {
-		t.Fatalf("scanFS: %v", err)
+		t.Fatalf("ScanFS: %v", err)
 	}
 
 	got := filePaths(idx)
@@ -68,18 +68,18 @@ func TestScan_DetectsGit(t *testing.T) {
 		"README.md": {Data: []byte("# r")},
 		".git/HEAD": {Data: []byte("ref: main")},
 	}
-	idx, err := scanFS(withGit, ".")
+	idx, err := ScanFS(withGit, ".")
 	if err != nil {
-		t.Fatalf("scanFS: %v", err)
+		t.Fatalf("ScanFS: %v", err)
 	}
 	if !idx.HasGit {
 		t.Errorf("HasGit = false, want true (a .git directory was present)")
 	}
 
 	noGit := fstest.MapFS{"README.md": {Data: []byte("# r")}}
-	idx, err = scanFS(noGit, ".")
+	idx, err = ScanFS(noGit, ".")
 	if err != nil {
-		t.Fatalf("scanFS: %v", err)
+		t.Fatalf("ScanFS: %v", err)
 	}
 	if idx.HasGit {
 		t.Errorf("HasGit = true, want false (no .git directory)")
@@ -94,9 +94,9 @@ func TestScan_BuildsByNameIndex(t *testing.T) {
 		"src/sub/main.go": {Data: []byte("package sub")},
 	}
 
-	idx, err := scanFS(fsys, ".")
+	idx, err := ScanFS(fsys, ".")
 	if err != nil {
-		t.Fatalf("scanFS: %v", err)
+		t.Fatalf("ScanFS: %v", err)
 	}
 
 	gotClaudes := append([]string(nil), idx.ByName["CLAUDE.md"]...)
@@ -122,7 +122,7 @@ func TestRead_ReturnsContent(t *testing.T) {
 	fsys := fstest.MapFS{
 		"CLAUDE.md": {Data: []byte("hello world")},
 	}
-	idx, _ := scanFS(fsys, ".")
+	idx, _ := ScanFS(fsys, ".")
 
 	got, err := idx.Read("CLAUDE.md")
 	if err != nil {
@@ -136,7 +136,7 @@ func TestRead_ReturnsContent(t *testing.T) {
 func TestRead_CapsAtSampleSize(t *testing.T) {
 	big := bytes.Repeat([]byte("x"), 200*1024) // 200 KiB > 64 KiB cap
 	fsys := fstest.MapFS{"big.txt": {Data: big}}
-	idx, _ := scanFS(fsys, ".")
+	idx, _ := ScanFS(fsys, ".")
 
 	got, err := idx.Read("big.txt")
 	if err != nil {
@@ -149,7 +149,7 @@ func TestRead_CapsAtSampleSize(t *testing.T) {
 
 func TestRead_NonExistentReturnsError(t *testing.T) {
 	fsys := fstest.MapFS{"a.txt": {Data: []byte("a")}}
-	idx, _ := scanFS(fsys, ".")
+	idx, _ := ScanFS(fsys, ".")
 
 	if _, err := idx.Read("missing.txt"); err == nil {
 		t.Errorf("Read of missing file: expected error, got nil")
@@ -161,7 +161,7 @@ func TestRead_CachesAcrossCalls(t *testing.T) {
 	count := &countingFS{
 		MapFS: fstest.MapFS{"a.txt": {Data: []byte("hi")}},
 	}
-	idx, _ := scanFS(count, ".")
+	idx, _ := ScanFS(count, ".")
 	count.opens = 0 // reset; the walk itself doesn't open file content
 
 	if _, err := idx.Read("a.txt"); err != nil {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,188 @@
+package scanner
+
+import (
+	"bytes"
+	"io/fs"
+	"slices"
+	"testing"
+	"testing/fstest"
+)
+
+// helper: collect the paths in a RepoIndex.Files in deterministic order.
+func filePaths(idx *RepoIndex) []string {
+	paths := make([]string, len(idx.Files))
+	for i, f := range idx.Files {
+		paths[i] = f.Path
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+func TestScan_IndexesAllNonIgnoredFiles(t *testing.T) {
+	fsys := fstest.MapFS{
+		"README.md":     {Data: []byte("# repo")},
+		"CLAUDE.md":     {Data: []byte("# claude\n\nrules")},
+		"src/main.go":   {Data: []byte("package main")},
+		"docs/intro.md": {Data: []byte("# intro")},
+	}
+
+	idx, err := scanFS(fsys, "/repo")
+	if err != nil {
+		t.Fatalf("scanFS: %v", err)
+	}
+	if idx.Root != "/repo" {
+		t.Errorf("Root = %q, want %q", idx.Root, "/repo")
+	}
+
+	want := []string{"CLAUDE.md", "README.md", "docs/intro.md", "src/main.go"}
+	got := filePaths(idx)
+	if !slices.Equal(got, want) {
+		t.Errorf("file paths = %v, want %v", got, want)
+	}
+}
+
+func TestScan_IgnoresDefaultPaths(t *testing.T) {
+	fsys := fstest.MapFS{
+		"README.md":             {Data: []byte("# repo")},
+		".git/config":           {Data: []byte("[core]")},
+		".git/HEAD":             {Data: []byte("ref: main")},
+		"node_modules/foo/x.js": {Data: []byte("x")},
+		"vendor/lib/lib.go":     {Data: []byte("package lib")},
+		"src/main.go":           {Data: []byte("package main")},
+	}
+
+	idx, err := scanFS(fsys, ".")
+	if err != nil {
+		t.Fatalf("scanFS: %v", err)
+	}
+
+	got := filePaths(idx)
+	want := []string{"README.md", "src/main.go"}
+	if !slices.Equal(got, want) {
+		t.Errorf("after default ignores, got %v, want %v", got, want)
+	}
+}
+
+func TestScan_DetectsGit(t *testing.T) {
+	withGit := fstest.MapFS{
+		"README.md": {Data: []byte("# r")},
+		".git/HEAD": {Data: []byte("ref: main")},
+	}
+	idx, err := scanFS(withGit, ".")
+	if err != nil {
+		t.Fatalf("scanFS: %v", err)
+	}
+	if !idx.HasGit {
+		t.Errorf("HasGit = false, want true (a .git directory was present)")
+	}
+
+	noGit := fstest.MapFS{"README.md": {Data: []byte("# r")}}
+	idx, err = scanFS(noGit, ".")
+	if err != nil {
+		t.Fatalf("scanFS: %v", err)
+	}
+	if idx.HasGit {
+		t.Errorf("HasGit = true, want false (no .git directory)")
+	}
+}
+
+func TestScan_BuildsByNameIndex(t *testing.T) {
+	fsys := fstest.MapFS{
+		"CLAUDE.md":       {Data: []byte("# top")},
+		"docs/CLAUDE.md":  {Data: []byte("# nested")},
+		"src/main.go":     {Data: []byte("package main")},
+		"src/sub/main.go": {Data: []byte("package sub")},
+	}
+
+	idx, err := scanFS(fsys, ".")
+	if err != nil {
+		t.Fatalf("scanFS: %v", err)
+	}
+
+	gotClaudes := append([]string(nil), idx.ByName["CLAUDE.md"]...)
+	slices.Sort(gotClaudes)
+	wantClaudes := []string{"CLAUDE.md", "docs/CLAUDE.md"}
+	if !slices.Equal(gotClaudes, wantClaudes) {
+		t.Errorf("ByName[CLAUDE.md] = %v, want %v", gotClaudes, wantClaudes)
+	}
+
+	gotMains := append([]string(nil), idx.ByName["main.go"]...)
+	slices.Sort(gotMains)
+	wantMains := []string{"src/main.go", "src/sub/main.go"}
+	if !slices.Equal(gotMains, wantMains) {
+		t.Errorf("ByName[main.go] = %v, want %v", gotMains, wantMains)
+	}
+
+	if got := idx.ByName["does-not-exist"]; got != nil {
+		t.Errorf("ByName[does-not-exist] = %v, want nil", got)
+	}
+}
+
+func TestRead_ReturnsContent(t *testing.T) {
+	fsys := fstest.MapFS{
+		"CLAUDE.md": {Data: []byte("hello world")},
+	}
+	idx, _ := scanFS(fsys, ".")
+
+	got, err := idx.Read("CLAUDE.md")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("Read = %q, want %q", got, "hello world")
+	}
+}
+
+func TestRead_CapsAtSampleSize(t *testing.T) {
+	big := bytes.Repeat([]byte("x"), 200*1024) // 200 KiB > 64 KiB cap
+	fsys := fstest.MapFS{"big.txt": {Data: big}}
+	idx, _ := scanFS(fsys, ".")
+
+	got, err := idx.Read("big.txt")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(got) != ReadSampleSize {
+		t.Errorf("Read of 200 KiB file returned %d bytes, want %d (ReadSampleSize)", len(got), ReadSampleSize)
+	}
+}
+
+func TestRead_NonExistentReturnsError(t *testing.T) {
+	fsys := fstest.MapFS{"a.txt": {Data: []byte("a")}}
+	idx, _ := scanFS(fsys, ".")
+
+	if _, err := idx.Read("missing.txt"); err == nil {
+		t.Errorf("Read of missing file: expected error, got nil")
+	}
+}
+
+func TestRead_CachesAcrossCalls(t *testing.T) {
+	// A counting fs.FS so we can assert Read is only called once per path.
+	count := &countingFS{
+		MapFS: fstest.MapFS{"a.txt": {Data: []byte("hi")}},
+	}
+	idx, _ := scanFS(count, ".")
+	count.opens = 0 // reset; the walk itself doesn't open file content
+
+	if _, err := idx.Read("a.txt"); err != nil {
+		t.Fatalf("first Read: %v", err)
+	}
+	if _, err := idx.Read("a.txt"); err != nil {
+		t.Fatalf("second Read: %v", err)
+	}
+	if count.opens != 1 {
+		t.Errorf("Read cache miss: fs.Open was called %d times across 2 reads, want 1", count.opens)
+	}
+}
+
+// countingFS wraps fstest.MapFS and counts Open calls so we can assert
+// that Read caches across calls.
+type countingFS struct {
+	fstest.MapFS
+	opens int
+}
+
+func (c *countingFS) Open(name string) (fs.File, error) {
+	c.opens++
+	return c.MapFS.Open(name)
+}

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -1,0 +1,122 @@
+// Package scoring rolls per-signal results into a Verdict. The math is
+// pinned by SPEC.md §7: per-level average (NA excluded), no level-skipping,
+// next_gap names not-yet-Found signals at the level above the verdict.
+package scoring
+
+import (
+	"slices"
+
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// DefaultPassThreshold is the minimum levelScore required to count a
+// level as "achieved." Configurable per-run via Options.PassThreshold.
+const DefaultPassThreshold = 0.7
+
+// Options tune the scoring pass for a single Compute call.
+type Options struct {
+	PassThreshold float64
+	MinConfidence acmm.Confidence
+}
+
+// Compute rolls a slice of per-signal results into a Verdict.
+func Compute(results []acmm.SignalResult, opts Options) acmm.Verdict {
+	threshold := opts.PassThreshold
+	if threshold == 0 {
+		threshold = DefaultPassThreshold
+	}
+	minConf := opts.MinConfidence
+	if minConf == "" {
+		minConf = acmm.ConfidenceLow
+	}
+
+	// Group results by level so we can compute per-level averages.
+	byLevel := map[acmm.Level][]acmm.SignalResult{}
+	for _, r := range results {
+		byLevel[r.Level] = append(byLevel[r.Level], r)
+	}
+
+	scores := make(map[acmm.Level]float64, 4)
+	for _, l := range []acmm.Level{
+		acmm.LevelInstructed,
+		acmm.LevelMeasured,
+		acmm.LevelAdaptive,
+		acmm.LevelSelfSustaining,
+	} {
+		scores[l] = levelScore(byLevel[l], minConf)
+	}
+
+	verdictLevel := acmm.LevelAssisted // L1 is the implicit floor.
+	for _, l := range []acmm.Level{
+		acmm.LevelInstructed,
+		acmm.LevelMeasured,
+		acmm.LevelAdaptive,
+		acmm.LevelSelfSustaining,
+	} {
+		if scores[l] >= threshold {
+			verdictLevel = l
+			continue
+		}
+		// First level that fails the threshold stops the climb — no skipping.
+		break
+	}
+
+	return acmm.Verdict{
+		Level:                verdictLevel,
+		Name:                 verdictLevel.Name(),
+		LevelScores:          scores,
+		NextGap:              nextGap(byLevel, verdictLevel),
+		MinConfidenceApplied: minConf,
+	}
+}
+
+// levelScore returns the average score across non-NA signals at a level,
+// after applying min-confidence downgrading. An empty (or all-NA) level
+// scores 0.0; that means we cannot pass a level we have no evidence for.
+func levelScore(results []acmm.SignalResult, minConf acmm.Confidence) float64 {
+	sum := 0.0
+	n := 0
+	for _, r := range results {
+		if r.Status == acmm.StatusNA {
+			continue
+		}
+		sum += gateAdjustedScore(r, minConf)
+		n++
+	}
+	if n == 0 {
+		return 0.0
+	}
+	return sum / float64(n)
+}
+
+// gateAdjustedScore implements the min-confidence rule from SPEC.md §6:
+// signals scoring below 1.0 at confidence below the gate are treated as
+// Missing (0.0) for verdict purposes. The maximum score (1.0) is always
+// honored regardless of confidence.
+func gateAdjustedScore(r acmm.SignalResult, minConf acmm.Confidence) float64 {
+	if r.Score >= acmm.ScoreFound {
+		return r.Score
+	}
+	if !r.Confidence.AtLeast(minConf) {
+		return 0.0
+	}
+	return r.Score
+}
+
+// nextGap returns the IDs of signals at the level above the verdict
+// that are not yet Found, ordered alphabetically by ID for determinism.
+// Empty when the verdict is already at the top of the ladder.
+func nextGap(byLevel map[acmm.Level][]acmm.SignalResult, verdict acmm.Level) []string {
+	if verdict >= acmm.LevelSelfSustaining {
+		return []string{}
+	}
+	target := verdict + 1
+	var ids []string
+	for _, r := range byLevel[target] {
+		if r.Score < acmm.ScoreFound {
+			ids = append(ids, r.ID)
+		}
+	}
+	slices.Sort(ids)
+	return ids
+}

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -1,0 +1,207 @@
+package scoring
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// helper: build a SignalResult quickly.
+func sr(id string, level acmm.Level, score float64, conf acmm.Confidence) acmm.SignalResult {
+	return acmm.SignalResult{
+		ID:         id,
+		Level:      level,
+		Family:     "test",
+		Status:     acmm.StatusFromScore(score),
+		Score:      score,
+		Confidence: conf,
+		Method:     acmm.MethodContentRegex,
+	}
+}
+
+func TestCompute_NoSignalsIsLevelOne(t *testing.T) {
+	v := Compute(nil, Options{})
+	if v.Level != acmm.LevelAssisted {
+		t.Errorf("Level = %d, want 1 (Assisted) for empty input", v.Level)
+	}
+	if v.Name != "Assisted" {
+		t.Errorf("Name = %q, want Assisted", v.Name)
+	}
+}
+
+func TestCompute_SingleL2FoundReachesLevelTwo(t *testing.T) {
+	results := []acmm.SignalResult{
+		sr("l2.x", acmm.LevelInstructed, acmm.ScoreFound, acmm.ConfidenceHigh),
+	}
+	v := Compute(results, Options{})
+	if v.Level != acmm.LevelInstructed {
+		t.Errorf("Level = %d, want 2", v.Level)
+	}
+	if got := v.LevelScores[acmm.LevelInstructed]; got != 1.0 {
+		t.Errorf("LevelScores[L2] = %v, want 1.0", got)
+	}
+}
+
+func TestCompute_SingleL2MissingStaysLevelOne(t *testing.T) {
+	results := []acmm.SignalResult{
+		sr("l2.x", acmm.LevelInstructed, acmm.ScoreMissing, acmm.ConfidenceHigh),
+	}
+	v := Compute(results, Options{})
+	if v.Level != acmm.LevelAssisted {
+		t.Errorf("Level = %d, want 1 (L2 below threshold)", v.Level)
+	}
+}
+
+func TestCompute_PassThresholdIsAverage(t *testing.T) {
+	// Two L2 signals; one Found, one Stubbed → avg = 0.665 → below 0.7 default.
+	results := []acmm.SignalResult{
+		sr("l2.a", acmm.LevelInstructed, acmm.ScoreFound, acmm.ConfidenceHigh),
+		sr("l2.b", acmm.LevelInstructed, acmm.ScoreStubbed, acmm.ConfidenceHigh),
+	}
+	v := Compute(results, Options{})
+	if v.Level != acmm.LevelAssisted {
+		t.Errorf("avg=0.665 should NOT pass default 0.7 threshold; Level = %d", v.Level)
+	}
+
+	// Found + Incomplete → avg = 0.835 → passes 0.7.
+	results[1] = sr("l2.b", acmm.LevelInstructed, acmm.ScoreIncomplete, acmm.ConfidenceHigh)
+	v = Compute(results, Options{})
+	if v.Level != acmm.LevelInstructed {
+		t.Errorf("avg=0.835 should pass 0.7 threshold; Level = %d", v.Level)
+	}
+}
+
+func TestCompute_NoSkipRule(t *testing.T) {
+	// L2 missing, L3 perfect → verdict is L1 because we can't skip L2.
+	results := []acmm.SignalResult{
+		sr("l2.x", acmm.LevelInstructed, acmm.ScoreMissing, acmm.ConfidenceHigh),
+		sr("l3.y", acmm.LevelMeasured, acmm.ScoreFound, acmm.ConfidenceHigh),
+	}
+	v := Compute(results, Options{})
+	if v.Level != acmm.LevelAssisted {
+		t.Errorf("Level = %d, want 1 (no-skip rule: L2 must pass before L3 counts)", v.Level)
+	}
+	// LevelScores still record what was observed at each level.
+	if v.LevelScores[acmm.LevelMeasured] != 1.0 {
+		t.Errorf("LevelScores[L3] = %v, want 1.0 (raw score is preserved even when level is gated)", v.LevelScores[acmm.LevelMeasured])
+	}
+}
+
+func TestCompute_HighestPassingLevelWins(t *testing.T) {
+	// L2 perfect, L3 perfect, L4 missing.
+	results := []acmm.SignalResult{
+		sr("l2.x", acmm.LevelInstructed, acmm.ScoreFound, acmm.ConfidenceHigh),
+		sr("l3.y", acmm.LevelMeasured, acmm.ScoreFound, acmm.ConfidenceHigh),
+		sr("l4.z", acmm.LevelAdaptive, acmm.ScoreMissing, acmm.ConfidenceHigh),
+	}
+	v := Compute(results, Options{})
+	if v.Level != acmm.LevelMeasured {
+		t.Errorf("Level = %d, want 3", v.Level)
+	}
+}
+
+func TestCompute_NextGapIsLevelPlusOne(t *testing.T) {
+	// L2 perfect, L3 partial → at L2, gap = the missing L3 signals.
+	results := []acmm.SignalResult{
+		sr("l2.x", acmm.LevelInstructed, acmm.ScoreFound, acmm.ConfidenceHigh),
+		sr("l3.coverage", acmm.LevelMeasured, acmm.ScoreMissing, acmm.ConfidenceHigh),
+		sr("l3.nightly", acmm.LevelMeasured, acmm.ScoreIncomplete, acmm.ConfidenceHigh),
+		sr("l3.flaky", acmm.LevelMeasured, acmm.ScoreFound, acmm.ConfidenceHigh),
+	}
+	v := Compute(results, Options{})
+
+	// next_gap names signals at L+1 (=L3) that are not Found, ordered by ID.
+	want := []string{"l3.coverage", "l3.nightly"}
+	if !slices.Equal(v.NextGap, want) {
+		t.Errorf("NextGap = %v, want %v", v.NextGap, want)
+	}
+}
+
+func TestCompute_NextGapEmptyAtLevelFive(t *testing.T) {
+	// All L2..L5 perfect → verdict is L5 → no next gap.
+	results := []acmm.SignalResult{
+		sr("l2.x", acmm.LevelInstructed, acmm.ScoreFound, acmm.ConfidenceHigh),
+		sr("l3.y", acmm.LevelMeasured, acmm.ScoreFound, acmm.ConfidenceHigh),
+		sr("l4.z", acmm.LevelAdaptive, acmm.ScoreFound, acmm.ConfidenceHigh),
+		sr("l5.w", acmm.LevelSelfSustaining, acmm.ScoreFound, acmm.ConfidenceHigh),
+	}
+	v := Compute(results, Options{})
+	if v.Level != acmm.LevelSelfSustaining {
+		t.Fatalf("Level = %d, want 5", v.Level)
+	}
+	if len(v.NextGap) != 0 {
+		t.Errorf("NextGap = %v, want empty at L5", v.NextGap)
+	}
+}
+
+func TestCompute_NAExcludedFromAverage(t *testing.T) {
+	results := []acmm.SignalResult{
+		sr("l2.applies", acmm.LevelInstructed, acmm.ScoreFound, acmm.ConfidenceHigh),
+		// NA signal — must not drag the average down.
+		{
+			ID: "l2.na", Level: acmm.LevelInstructed, Family: "test",
+			Status: acmm.StatusNA, Score: 0.0, Confidence: acmm.ConfidenceHigh,
+		},
+	}
+	v := Compute(results, Options{})
+	if got := v.LevelScores[acmm.LevelInstructed]; got != 1.0 {
+		t.Errorf("LevelScores[L2] with one NA = %v, want 1.0", got)
+	}
+	if v.Level != acmm.LevelInstructed {
+		t.Errorf("Level = %d, want 2 (NA must not block the verdict)", v.Level)
+	}
+}
+
+func TestCompute_MinConfidenceDowngradesPartialScores(t *testing.T) {
+	// Score=0.67 at Medium confidence: counts at default min-confidence=Low,
+	// is downgraded to 0 at min-confidence=High.
+	results := []acmm.SignalResult{
+		sr("l2.x", acmm.LevelInstructed, acmm.ScoreIncomplete, acmm.ConfidenceMedium),
+	}
+	low := Compute(results, Options{MinConfidence: acmm.ConfidenceLow})
+	if low.LevelScores[acmm.LevelInstructed] != acmm.ScoreIncomplete {
+		t.Errorf("at min=low, level score = %v, want %v", low.LevelScores[acmm.LevelInstructed], acmm.ScoreIncomplete)
+	}
+
+	high := Compute(results, Options{MinConfidence: acmm.ConfidenceHigh})
+	if high.LevelScores[acmm.LevelInstructed] != 0.0 {
+		t.Errorf("at min=high, partial+medium should be downgraded to 0; got %v", high.LevelScores[acmm.LevelInstructed])
+	}
+
+	// But Score=1.0 (fully Found) at Medium confidence is NOT downgraded —
+	// the maximum score is trusted regardless of confidence.
+	results = []acmm.SignalResult{
+		sr("l2.y", acmm.LevelInstructed, acmm.ScoreFound, acmm.ConfidenceMedium),
+	}
+	v := Compute(results, Options{MinConfidence: acmm.ConfidenceHigh})
+	if v.LevelScores[acmm.LevelInstructed] != 1.0 {
+		t.Errorf("Found at Medium should keep 1.0 even at min=high; got %v", v.LevelScores[acmm.LevelInstructed])
+	}
+}
+
+func TestCompute_VerdictRecordsMinConfidenceApplied(t *testing.T) {
+	v := Compute(nil, Options{MinConfidence: acmm.ConfidenceHigh})
+	if v.MinConfidenceApplied != acmm.ConfidenceHigh {
+		t.Errorf("MinConfidenceApplied = %q, want high", v.MinConfidenceApplied)
+	}
+
+	// Default (zero value) → low.
+	v = Compute(nil, Options{})
+	if v.MinConfidenceApplied != acmm.ConfidenceLow {
+		t.Errorf("default MinConfidenceApplied = %q, want low", v.MinConfidenceApplied)
+	}
+}
+
+func TestCompute_CustomThreshold(t *testing.T) {
+	// 0.67 at default 0.7 → fails. At 0.6 → passes.
+	results := []acmm.SignalResult{
+		sr("l2.x", acmm.LevelInstructed, acmm.ScoreIncomplete, acmm.ConfidenceHigh),
+	}
+	if v := Compute(results, Options{}); v.Level != acmm.LevelAssisted {
+		t.Errorf("with default threshold, level = %d, want 1", v.Level)
+	}
+	if v := Compute(results, Options{PassThreshold: 0.6}); v.Level != acmm.LevelInstructed {
+		t.Errorf("with threshold=0.6, level = %d, want 2", v.Level)
+	}
+}

--- a/internal/signals/l2/claude_md.go
+++ b/internal/signals/l2/claude_md.go
@@ -1,0 +1,116 @@
+// Package l2 holds Level 2 (Instructed) signals — encoded preferences
+// in instruction files that AI agents consume at the start of every
+// session. See SPEC.md §6.
+package l2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+
+	"github.com/sroberts/plumbline/internal/scanner"
+	"github.com/sroberts/plumbline/internal/signals"
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// claudeMDPath is the file the signal looks for at the repo root.
+const claudeMDPath = "CLAUDE.md"
+
+// claudeMDLineThreshold is the bar for "substantive" content. Below it,
+// the file is treated as a stub even when it has a heading.
+const claudeMDLineThreshold = 30
+
+// ClaudeMD detects whether a substantive CLAUDE.md exists at the repo
+// root. Found requires both a markdown heading and ≥ 30 non-blank lines
+// of content.
+type ClaudeMD struct{}
+
+func (ClaudeMD) ID() string        { return "l2.claude-md" }
+func (ClaudeMD) Level() acmm.Level { return acmm.LevelInstructed }
+func (ClaudeMD) Family() string    { return "instructions" }
+func (ClaudeMD) Title() string     { return "CLAUDE.md present and substantive" }
+
+func (s ClaudeMD) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result {
+	data, err := idx.Read(claudeMDPath)
+	if err != nil {
+		// File-not-found is the expected Missing case; any other error
+		// is also Missing for now (signals don't propagate errors —
+		// the verdict caller cannot do anything with them).
+		if errors.Is(err, fs.ErrNotExist) {
+			return acmm.Result{
+				Status:     acmm.StatusMissing,
+				Score:      acmm.ScoreMissing,
+				Confidence: acmm.ConfidenceHigh,
+				Method:     acmm.MethodContentRegex,
+			}
+		}
+		return acmm.Result{
+			Status:     acmm.StatusMissing,
+			Score:      acmm.ScoreMissing,
+			Confidence: acmm.ConfidenceHigh,
+			Method:     acmm.MethodContentRegex,
+			Notes:      []string{"could not read CLAUDE.md: " + err.Error()},
+		}
+	}
+
+	hasHeading := containsHeading(data)
+	nonBlank := countNonBlankLines(data)
+	hasBody := nonBlank >= claudeMDLineThreshold
+
+	score := acmm.ScoreStubbed
+	switch {
+	case hasHeading && hasBody:
+		score = acmm.ScoreFound
+	case hasHeading || hasBody:
+		score = acmm.ScoreIncomplete
+	}
+
+	return acmm.Result{
+		Status:     acmm.StatusFromScore(score),
+		Score:      score,
+		Confidence: acmm.ConfidenceMedium,
+		Method:     acmm.MethodContentRegex,
+		Evidence: []acmm.Evidence{{
+			Path:    claudeMDPath,
+			Excerpt: excerpt(data, 160),
+		}},
+	}
+}
+
+// containsHeading reports whether data contains at least one ATX-style
+// markdown heading (# / ## / ###...) at the start of any line.
+func containsHeading(data []byte) bool {
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		trimmed := bytes.TrimLeft(line, " \t")
+		if len(trimmed) > 0 && trimmed[0] == '#' {
+			return true
+		}
+	}
+	return false
+}
+
+// countNonBlankLines returns the number of lines containing at least
+// one non-whitespace character.
+func countNonBlankLines(data []byte) int {
+	n := 0
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) > 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// excerpt returns the first n bytes of data, with a trailing ellipsis
+// if truncated. Used in Evidence so the verdict has a citation.
+func excerpt(data []byte, n int) string {
+	if len(data) <= n {
+		return string(data)
+	}
+	return string(data[:n]) + "…"
+}
+
+func init() {
+	signals.Default.Register(ClaudeMD{})
+}

--- a/internal/signals/l2/claude_md_test.go
+++ b/internal/signals/l2/claude_md_test.go
@@ -1,0 +1,135 @@
+package l2
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/sroberts/plumbline/internal/scanner"
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+func TestClaudeMD_Identity(t *testing.T) {
+	s := ClaudeMD{}
+	if s.ID() != "l2.claude-md" {
+		t.Errorf("ID = %q, want l2.claude-md", s.ID())
+	}
+	if s.Level() != acmm.LevelInstructed {
+		t.Errorf("Level = %v, want LevelInstructed", s.Level())
+	}
+	if s.Family() != "instructions" {
+		t.Errorf("Family = %q, want instructions", s.Family())
+	}
+	if s.Title() == "" {
+		t.Error("Title is empty")
+	}
+}
+
+func TestClaudeMD_Detect(t *testing.T) {
+	// 35 non-blank lines of "guidance" — exceeds the 30-line bar.
+	longBody := strings.Repeat("Some non-trivial line of guidance.\n", 35)
+
+	cases := []struct {
+		name           string
+		files          fstest.MapFS
+		wantStatus     acmm.Status
+		wantScore      float64
+		wantConfidence acmm.Confidence
+	}{
+		{
+			name:           "absent",
+			files:          fstest.MapFS{"README.md": {Data: []byte("# r")}},
+			wantStatus:     acmm.StatusMissing,
+			wantScore:      acmm.ScoreMissing,
+			wantConfidence: acmm.ConfidenceHigh,
+		},
+		{
+			name: "present in subdir but not at root",
+			files: fstest.MapFS{
+				"docs/CLAUDE.md": {Data: []byte("# CLAUDE\n\n" + longBody)},
+			},
+			wantStatus:     acmm.StatusMissing,
+			wantScore:      acmm.ScoreMissing,
+			wantConfidence: acmm.ConfidenceHigh,
+		},
+		{
+			name: "stubbed: no heading and few lines",
+			files: fstest.MapFS{
+				"CLAUDE.md": {Data: []byte("just plain text\nno markdown\nthree lines\n")},
+			},
+			wantStatus:     acmm.StatusPartial,
+			wantScore:      acmm.ScoreStubbed,
+			wantConfidence: acmm.ConfidenceMedium,
+		},
+		{
+			name: "incomplete: heading but few lines",
+			files: fstest.MapFS{
+				"CLAUDE.md": {Data: []byte("# CLAUDE.md\n\nshort guide.\n")},
+			},
+			wantStatus:     acmm.StatusPartial,
+			wantScore:      acmm.ScoreIncomplete,
+			wantConfidence: acmm.ConfidenceMedium,
+		},
+		{
+			name: "incomplete: many lines but no heading",
+			files: fstest.MapFS{
+				"CLAUDE.md": {Data: []byte(longBody)},
+			},
+			wantStatus:     acmm.StatusPartial,
+			wantScore:      acmm.ScoreIncomplete,
+			wantConfidence: acmm.ConfidenceMedium,
+		},
+		{
+			name: "found: heading and >= 30 non-blank lines",
+			files: fstest.MapFS{
+				"CLAUDE.md": {Data: []byte("# CLAUDE.md\n\n" + longBody)},
+			},
+			wantStatus:     acmm.StatusFound,
+			wantScore:      acmm.ScoreFound,
+			wantConfidence: acmm.ConfidenceMedium,
+		},
+		{
+			name: "blank lines do not count toward the 30-line bar",
+			files: fstest.MapFS{
+				// 35 lines of just newlines + a heading + 5 content lines.
+				"CLAUDE.md": {Data: []byte("# CLAUDE.md\n" + strings.Repeat("\n", 35) + "a\nb\nc\nd\ne\n")},
+			},
+			wantStatus:     acmm.StatusPartial,
+			wantScore:      acmm.ScoreIncomplete,
+			wantConfidence: acmm.ConfidenceMedium,
+		},
+	}
+
+	s := ClaudeMD{}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			idx, err := scanner.ScanFS(c.files, "/repo")
+			if err != nil {
+				t.Fatalf("ScanFS: %v", err)
+			}
+			got := s.Detect(context.Background(), idx)
+			if got.Status != c.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, c.wantStatus)
+			}
+			if got.Score != c.wantScore {
+				t.Errorf("Score = %v, want %v", got.Score, c.wantScore)
+			}
+			if got.Confidence != c.wantConfidence {
+				t.Errorf("Confidence = %q, want %q", got.Confidence, c.wantConfidence)
+			}
+			// Method and Evidence must be set; concrete values are
+			// implementation choices not pinned by these tests.
+			if got.Method == "" {
+				t.Error("Method is empty")
+			}
+			if got.Status == acmm.StatusMissing && len(got.Evidence) > 0 {
+				t.Errorf("Missing should have no evidence, got %d entries", len(got.Evidence))
+			}
+			if got.Status != acmm.StatusMissing && len(got.Evidence) == 0 {
+				t.Error("non-Missing result should carry at least one Evidence entry")
+			}
+		})
+	}
+}

--- a/internal/signals/registry.go
+++ b/internal/signals/registry.go
@@ -1,0 +1,106 @@
+// Package signals defines the Signal interface and the registry that
+// holds every detector plumbline knows about. Concrete signals live in
+// subpackages (l2, l3, l4, l5) and register themselves via init().
+package signals
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/sroberts/plumbline/internal/scanner"
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// Signal is the unit of pluggability. One file per signal under
+// internal/signals/lN/. See SPEC.md §6.
+type Signal interface {
+	ID() string
+	Level() acmm.Level
+	Family() string
+	Title() string
+	Detect(ctx context.Context, idx *scanner.RepoIndex) acmm.Result
+}
+
+// Registry holds the set of known signals. The CLI uses Default for
+// production scans; tests construct fresh registries with NewRegistry.
+type Registry struct {
+	byID map[string]Signal
+}
+
+// NewRegistry returns an empty Registry suitable for tests and for
+// alternate signal sets.
+func NewRegistry() *Registry {
+	return &Registry{byID: make(map[string]Signal)}
+}
+
+// Register adds s to the registry. Panics on duplicate ID — signal IDs
+// are part of the public contract and collisions indicate a programming
+// error rather than something to recover from at runtime.
+func (r *Registry) Register(s Signal) {
+	id := s.ID()
+	if _, exists := r.byID[id]; exists {
+		panic(fmt.Sprintf("signals: duplicate registration for %q", id))
+	}
+	r.byID[id] = s
+}
+
+// Get returns the signal with the given ID, or false if not registered.
+func (r *Registry) Get(id string) (Signal, bool) {
+	s, ok := r.byID[id]
+	return s, ok
+}
+
+// All returns every registered signal in deterministic (level, id) order.
+func (r *Registry) All() []Signal {
+	out := make([]Signal, 0, len(r.byID))
+	for _, s := range r.byID {
+		out = append(out, s)
+	}
+	sortByLevelAndID(out)
+	return out
+}
+
+// AtLevel returns signals at the given ACMM level, in deterministic order.
+func (r *Registry) AtLevel(l acmm.Level) []Signal {
+	out := make([]Signal, 0)
+	for _, s := range r.byID {
+		if s.Level() == l {
+			out = append(out, s)
+		}
+	}
+	sortByLevelAndID(out)
+	return out
+}
+
+// InFamily returns signals in the given family, in deterministic order.
+func (r *Registry) InFamily(name string) []Signal {
+	out := make([]Signal, 0)
+	for _, s := range r.byID {
+		if s.Family() == name {
+			out = append(out, s)
+		}
+	}
+	sortByLevelAndID(out)
+	return out
+}
+
+func sortByLevelAndID(sigs []Signal) {
+	slices.SortFunc(sigs, func(a, b Signal) int {
+		if a.Level() != b.Level() {
+			return int(a.Level()) - int(b.Level())
+		}
+		switch {
+		case a.ID() < b.ID():
+			return -1
+		case a.ID() > b.ID():
+			return 1
+		}
+		return 0
+	})
+}
+
+// Default is the package-level singleton populated by signal subpackages
+// at init() time. The CLI uses this for production scans; tests should
+// prefer NewRegistry() to avoid global state.
+var Default = NewRegistry()

--- a/internal/signals/registry_test.go
+++ b/internal/signals/registry_test.go
@@ -1,0 +1,118 @@
+package signals
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/sroberts/plumbline/internal/scanner"
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// fakeSignal is a minimal Signal used to drive registry tests.
+type fakeSignal struct {
+	id     string
+	level  acmm.Level
+	family string
+	title  string
+	result acmm.Result
+}
+
+func (f *fakeSignal) ID() string                                                 { return f.id }
+func (f *fakeSignal) Level() acmm.Level                                          { return f.level }
+func (f *fakeSignal) Family() string                                             { return f.family }
+func (f *fakeSignal) Title() string                                              { return f.title }
+func (f *fakeSignal) Detect(_ context.Context, _ *scanner.RepoIndex) acmm.Result { return f.result }
+
+func idsOf(sigs []Signal) []string {
+	out := make([]string, len(sigs))
+	for i, s := range sigs {
+		out[i] = s.ID()
+	}
+	return out
+}
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+	s := &fakeSignal{id: "l2.test", level: acmm.LevelInstructed, family: "test"}
+	r.Register(s)
+
+	got, ok := r.Get("l2.test")
+	if !ok {
+		t.Fatal("Get(l2.test): not found")
+	}
+	if got.ID() != "l2.test" {
+		t.Errorf("Get returned signal with ID %q, want l2.test", got.ID())
+	}
+
+	_, ok = r.Get("missing")
+	if ok {
+		t.Error("Get(missing): expected not found")
+	}
+}
+
+func TestRegistry_DuplicateIDPanics(t *testing.T) {
+	r := NewRegistry()
+	s := &fakeSignal{id: "l2.dup", level: acmm.LevelInstructed, family: "test"}
+	r.Register(s)
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on duplicate registration")
+		}
+	}()
+	r.Register(s)
+}
+
+func TestRegistry_AllReturnsDeterministicOrder(t *testing.T) {
+	r := NewRegistry()
+	// Register in non-sorted order. All() must sort by (level, id).
+	r.Register(&fakeSignal{id: "l3.b", level: acmm.LevelMeasured, family: "y"})
+	r.Register(&fakeSignal{id: "l2.a", level: acmm.LevelInstructed, family: "x"})
+	r.Register(&fakeSignal{id: "l3.a", level: acmm.LevelMeasured, family: "x"})
+	r.Register(&fakeSignal{id: "l4.a", level: acmm.LevelAdaptive, family: "z"})
+
+	got := idsOf(r.All())
+	want := []string{"l2.a", "l3.a", "l3.b", "l4.a"}
+	if !slices.Equal(got, want) {
+		t.Errorf("All() = %v, want %v", got, want)
+	}
+}
+
+func TestRegistry_AtLevel(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&fakeSignal{id: "l2.a", level: acmm.LevelInstructed, family: "x"})
+	r.Register(&fakeSignal{id: "l3.b", level: acmm.LevelMeasured, family: "y"})
+	r.Register(&fakeSignal{id: "l3.c", level: acmm.LevelMeasured, family: "y"})
+
+	got := idsOf(r.AtLevel(acmm.LevelMeasured))
+	want := []string{"l3.b", "l3.c"}
+	if !slices.Equal(got, want) {
+		t.Errorf("AtLevel(L3) = %v, want %v", got, want)
+	}
+
+	got = idsOf(r.AtLevel(acmm.LevelAdaptive))
+	if len(got) != 0 {
+		t.Errorf("AtLevel(L4) = %v, want empty", got)
+	}
+}
+
+func TestRegistry_InFamily(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&fakeSignal{id: "l2.a", level: acmm.LevelInstructed, family: "instructions"})
+	r.Register(&fakeSignal{id: "l2.b", level: acmm.LevelInstructed, family: "templates"})
+	r.Register(&fakeSignal{id: "l3.c", level: acmm.LevelMeasured, family: "instructions"})
+
+	got := idsOf(r.InFamily("instructions"))
+	want := []string{"l2.a", "l3.c"}
+	if !slices.Equal(got, want) {
+		t.Errorf("InFamily(instructions) = %v, want %v", got, want)
+	}
+}
+
+func TestRegistry_NewIsEmpty(t *testing.T) {
+	r := NewRegistry()
+	if len(r.All()) != 0 {
+		t.Errorf("fresh registry has %d signals, want 0", len(r.All()))
+	}
+}


### PR DESCRIPTION
First end-to-end vertical slice of the M1 pipeline. \`./plumbline assess --json /some/repo\` now walks the repo, runs the registered signals, computes a verdict per the SPEC.md §7 math, and emits a \`plumbline/v1\` Report.

Built strictly TDD per the project rule: every commit on the branch lands a failing test first, then the implementation that makes it pass. CI ran green locally on every commit.

## Summary

Five commits, one per logical chunk:

1. **\`scanner\`** — \`internal/scanner.RepoIndex\` walks an \`fs.FS\` (real via \`os.DirFS\`, tested via \`fstest.MapFS\`), excludes \`.git\` / \`node_modules\` / \`vendor\`, builds a basename index, and exposes \`idx.Read\` as the **single sanctioned IO chokepoint** with a 64 KiB sample cap and per-scan caching. Eight tests cover walking, ignores, \`.git\` detection, \`ByName\`, content reads, the cap, missing-file errors, and read caching (verified via a counting \`fs.FS\`).
2. **\`signals\` registry** — \`Signal\` interface, \`Registry\` with \`Register\` / \`Get\` / \`All\` / \`AtLevel\` / \`InFamily\`. Deterministic \`(level, id)\` ordering. Duplicate-ID registration panics. Tests cover all of the above. Also exports \`scanner.ScanFS\` for use from signal tests.
3. **\`signals/l2.ClaudeMD\`** — first concrete signal. Maps onto the four-step rubric: \`Missing\` if absent, \`Stubbed\` if neither heading nor body, \`Incomplete\` if one of the two, \`Found\` if both heading and ≥30 non-blank lines. Confidence \`High\` when \`Missing\` (file existence is unambiguous), \`Medium\` otherwise. Eight subtests cover all rubric branches plus the blank-line edge case. Registers into \`signals.Default\` via \`init()\`.
4. **\`scoring\`** — per-level averages with NA exclusion, the no-skip rule (\`Verdict.Level\` is the highest \`L\` where every \`k ∈ 2..L\` meets the threshold), \`NextGap\` listing the not-yet-Found signals at \`L+1\`, and the min-confidence downgrade (signals scoring < 1.0 at confidence below the gate count as 0). 12 tests covering all of these, including custom thresholds and the L5-cap.
5. **\`assess\` wired up** — \`runAssess(ctx, path, opts)\` is the testable pipeline; \`--json\` emits a \`plumbline/v1\` Report; default text is a brief summary + next-gap panel. Three behavior tests use \`t.TempDir()\` + \`json.Unmarshal\` to assert the full contract. Signal registration happens via a blank import in \`registrations.go\`.

Plumbline now scores itself: \`./plumbline assess\` against this repo correctly reports L1 with \`l2.claude-md\` at 0.67 (heading present, but CLAUDE.md has only 27 non-blank lines, just under the 30-line bar). Dogfooding works.

## What's deferred

- The richer text output (level bars, etc.) and \`inspect\` / \`signals\` / \`explain\` / \`schema\` commands stay stubbed for the next PRs.
- L3+ signals.
- NDJSON event stream (\`--events\`).
- Help text contract / schema contract tests.

## Test plan

- [ ] \`make test\` — full suite green
- [ ] \`make build && ./plumbline assess\` — brief text output for the current repo
- [ ] \`./plumbline assess --json | jq .verdict.level\` — emits valid JSON
- [ ] \`./plumbline assess /nonexistent/path\` exits with code 2
- [ ] \`./plumbline assess --min-confidence high\` accepts the flag (no behavior change yet without partial-credit signals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)