### PR TITLE
cmd: bare 'plumbline' runs the assess pipeline by default

### DIFF
--- a/cmd/plumbline/assess.go
+++ b/cmd/plumbline/assess.go
@@ -23,29 +23,150 @@ import (
 	"github.com/sroberts/plumbline/pkg/acmm"
 )
 
+// assessFlags holds every flag the assess pipeline understands. Both
+// the `assess` subcommand and the root command bind the same struct so
+// `plumbline [path]` and `plumbline assess [path]` are at flag parity.
+type assessFlags struct {
+	asJSON        bool
+	reportFmt     string
+	outPath       string
+	eventsFmt     string
+	quiet         bool
+	noColor       bool
+	cli           bool
+	forceTUI      bool
+	failBelow     int
+	profile       string
+	configPath    string
+	minConfidence string
+	signalSet     string
+	ciSystem      string
+	debug         bool
+	clock         string
+	includeSignal []string
+	excludeSignal []string
+	levelFilters  []int
+	familyFilters []string
+}
+
+// bindAssessFlags registers the assess flag set on cmd. Used by the
+// assess subcommand and by the root command's default action.
+func bindAssessFlags(cmd *cobra.Command, f *assessFlags) {
+	fs := cmd.Flags()
+	fs.BoolVar(&f.asJSON, "json", false, "Emit JSON to stdout. Implies --cli. Schema: 'plumbline schema verdict'.")
+	fs.StringVar(&f.reportFmt, "report", "", "Write a report file. fmt: markdown|json|sarif. Implies --cli.")
+	fs.StringVar(&f.outPath, "out", "-", "Report destination. \"-\" = stdout.")
+	fs.StringVar(&f.eventsFmt, "events", "", "Stream progress events to stderr. fmt: ndjson|text. Schema: 'plumbline schema event'.")
+	fs.BoolVarP(&f.quiet, "quiet", "q", false, "Suppress banners, progress, and trailing hints. Implies --cli.")
+	fs.BoolVar(&f.noColor, "no-color", false, "Disable ANSI color (also via NO_COLOR=1).")
+	fs.BoolVar(&f.cli, "cli", false, "Force pure-CLI mode. Auto-set when stdout is not a TTY.")
+	fs.BoolVar(&f.forceTUI, "tui", false, "Force TUI even when stdout is not a TTY.")
+	fs.IntVar(&f.failBelow, "fail-below", 0, "Exit 1 if assessed level < N (2-5). 0 = no gate.")
+	fs.StringVar(&f.profile, "profile", "default", "Named signal preset. See 'plumbline help profiles'.")
+	fs.StringVar(&f.configPath, "config", "", "Override config path. Default: .plumbline.yml.")
+	fs.StringVar(&f.minConfidence, "min-confidence", "low", "Minimum confidence to credit a signal: low|medium|high.")
+	fs.StringVar(&f.signalSet, "signal-set", "latest", "Pin signal rule-set version (e.g., v1).")
+	fs.StringVar(&f.ciSystem, "ci-system", "auto", "CI flavor: auto|github-actions. Other systems are M4+.")
+	fs.BoolVar(&f.debug, "debug", false, "Emit detection diagnostics on stderr. Implies --cli.")
+	fs.StringVar(&f.clock, "clock", "wall", "Timestamp source for events: wall|fixed|relative.")
+	fs.StringSliceVar(&f.includeSignal, "include-signal", nil, "Only run the listed signals. Repeatable.")
+	fs.StringSliceVar(&f.excludeSignal, "exclude-signal", nil, "Skip the listed signals. Repeatable.")
+	fs.IntSliceVar(&f.levelFilters, "level", nil, "Only run signals at level N (2-5). Repeatable.")
+	fs.StringSliceVar(&f.familyFilters, "family", nil, "Only run signals in family <name>. Repeatable.")
+}
+
+// makeAssessRunE returns a cobra RunE closure that drives the assess
+// pipeline using the bound flags + provided I/O. Used by both the
+// assess subcommand and the root command.
+func makeAssessRunE(flags *assessFlags, stdout, stderr io.Writer) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if flags.cli && flags.forceTUI {
+			return errCannotRun(errors.New("--cli and --tui are mutually exclusive"))
+		}
+		if len(flags.includeSignal) > 0 && len(flags.excludeSignal) > 0 {
+			return errCannotRun(errors.New("--include-signal and --exclude-signal are mutually exclusive"))
+		}
+		if flags.reportFmt != "" && flags.reportFmt != "json" && flags.reportFmt != "markdown" && flags.reportFmt != "sarif" {
+			return errCannotRun(fmt.Errorf("invalid --report %q (want json|markdown|sarif)", flags.reportFmt))
+		}
+		if flags.eventsFmt != "" && flags.eventsFmt != "ndjson" && flags.eventsFmt != "text" {
+			return errCannotRun(fmt.Errorf("invalid --events %q (want ndjson|text)", flags.eventsFmt))
+		}
+
+		path := "."
+		if len(args) == 1 {
+			path = args[0]
+		}
+
+		confLevel, err := parseConfidence(flags.minConfidence)
+		if err != nil {
+			return errCannotRun(err)
+		}
+
+		emitter := report.NewEventEmitter(stderr, flags.eventsFmt == "ndjson")
+
+		pipelineOpts := pipelineOptions{
+			IncludeSignal: flags.includeSignal,
+			ExcludeSignal: flags.excludeSignal,
+			LevelFilters:  flags.levelFilters,
+			FamilyFilters: flags.familyFilters,
+			Scoring:       scoring.Options{MinConfidence: confLevel},
+			Events:        emitter,
+			Debug:         flags.debug,
+			DebugStderr:   stderr,
+		}
+
+		// Mode selection per SPEC.md §4.
+		modeIsTUI := flags.forceTUI ||
+			(!flags.cli && !flags.asJSON && flags.reportFmt == "" &&
+				flags.eventsFmt == "" && !flags.quiet && !flags.debug &&
+				stdoutIsTerminal(stdout))
+
+		if modeIsTUI {
+			rpt, err := tui.Run(func(ctx context.Context) (acmm.Report, error) {
+				return runAssess(ctx, path, pipelineOpts)
+			})
+			if err != nil {
+				return errCannotRun(err)
+			}
+			if flags.failBelow > 0 && int(rpt.Verdict.Level) < flags.failBelow {
+				return &exitError{code: exitGateFailed, err: fmt.Errorf("verdict level %d is below --fail-below %d", rpt.Verdict.Level, flags.failBelow)}
+			}
+			return nil
+		}
+
+		rpt, err := runAssess(cmd.Context(), path, pipelineOpts)
+		if err != nil {
+			return errCannotRun(err)
+		}
+
+		switch {
+		case flags.reportFmt != "":
+			if err := writeReport(rpt, flags.reportFmt, flags.outPath, stdout); err != nil {
+				return errCannotRun(err)
+			}
+		case flags.asJSON:
+			enc := json.NewEncoder(stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(rpt); err != nil {
+				return errCannotRun(err)
+			}
+		case !flags.quiet:
+			writeBriefText(stdout, rpt)
+		}
+
+		if flags.failBelow > 0 && int(rpt.Verdict.Level) < flags.failBelow {
+			return &exitError{
+				code: exitGateFailed,
+				err:  fmt.Errorf("verdict level %d is below --fail-below %d", rpt.Verdict.Level, flags.failBelow),
+			}
+		}
+		return nil
+	}
+}
+
 func newAssessCmd(stdout, stderr io.Writer) *cobra.Command {
-	var (
-		asJSON        bool
-		reportFmt     string
-		outPath       string
-		eventsFmt     string
-		quiet         bool
-		noColor       bool
-		cli           bool
-		forceTUI      bool
-		failBelow     int
-		profile       string
-		configPath    string
-		minConfidence string
-		signalSet     string
-		ciSystem      string
-		debug         bool
-		clock         string
-		includeSignal []string
-		excludeSignal []string
-		levelFilters  []int
-		familyFilters []string
-	)
+	flags := &assessFlags{}
 
 	cmd := &cobra.Command{
 		Use:   "assess [path]",
@@ -59,21 +180,27 @@ scores, and the list of signals that would unlock the next level.
 Mode is auto-detected: TUI on a terminal, CLI when piped or in CI.
 Use --cli to force non-interactive output, --tui to force the TUI.
 
+This command is also the default — running 'plumbline [path]' without
+a subcommand is equivalent to 'plumbline assess [path]'.
+
 Examples:
-  # Interactive TUI: scan the current directory.
+  # Bare invocation: scan the current directory (TUI on a terminal).
+  plumbline
+
+  # Same, explicit subcommand.
   plumbline assess
 
   # Machine-readable, with progress events on stderr.
-  plumbline assess --json --events ndjson 2>events.log >verdict.json
+  plumbline --json --events ndjson 2>events.log >verdict.json
 
   # CI gate: fail if not at level 3 or higher.
-  plumbline assess --fail-below 3 --quiet
+  plumbline --fail-below 3 --quiet
 
   # Scan a specific repo, save markdown report.
-  plumbline assess /path/to/repo --report markdown --out maturity.md
+  plumbline /path/to/repo --report markdown --out maturity.md
 
   # Only run the L3 coverage signals.
-  plumbline assess --level 3 --family coverage --json
+  plumbline --level 3 --family coverage --json
 
 Exit codes:
   0  scan completed; gate passed (or no gate set)
@@ -87,112 +214,9 @@ See also:
   plumbline help scoring     how levels and the no-skip rule are computed
   plumbline help agents      guidance for LLM tool callers`,
 		Args: cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if cli && forceTUI {
-				return errCannotRun(errors.New("--cli and --tui are mutually exclusive"))
-			}
-			if len(includeSignal) > 0 && len(excludeSignal) > 0 {
-				return errCannotRun(errors.New("--include-signal and --exclude-signal are mutually exclusive"))
-			}
-			if reportFmt != "" && reportFmt != "json" && reportFmt != "markdown" && reportFmt != "sarif" {
-				return errCannotRun(fmt.Errorf("invalid --report %q (want json|markdown|sarif)", reportFmt))
-			}
-			if eventsFmt != "" && eventsFmt != "ndjson" && eventsFmt != "text" {
-				return errCannotRun(fmt.Errorf("invalid --events %q (want ndjson|text)", eventsFmt))
-			}
-
-			path := "."
-			if len(args) == 1 {
-				path = args[0]
-			}
-
-			confLevel, err := parseConfidence(minConfidence)
-			if err != nil {
-				return errCannotRun(err)
-			}
-
-			emitter := report.NewEventEmitter(stderr, eventsFmt == "ndjson")
-
-			pipelineOpts := pipelineOptions{
-				IncludeSignal: includeSignal,
-				ExcludeSignal: excludeSignal,
-				LevelFilters:  levelFilters,
-				FamilyFilters: familyFilters,
-				Scoring:       scoring.Options{MinConfidence: confLevel},
-				Events:        emitter,
-				Debug:         debug,
-				DebugStderr:   stderr,
-			}
-
-			// Mode selection per SPEC.md §4.
-			modeIsTUI := forceTUI || (!cli && !asJSON && reportFmt == "" && eventsFmt == "" && !quiet && !debug && stdoutIsTerminal(stdout))
-
-			if modeIsTUI {
-				rpt, err := tui.Run(func(ctx context.Context) (acmm.Report, error) {
-					return runAssess(ctx, path, pipelineOpts)
-				})
-				if err != nil {
-					return errCannotRun(err)
-				}
-				if failBelow > 0 && int(rpt.Verdict.Level) < failBelow {
-					return &exitError{code: exitGateFailed, err: fmt.Errorf("verdict level %d is below --fail-below %d", rpt.Verdict.Level, failBelow)}
-				}
-				return nil
-			}
-
-			rpt, err := runAssess(cmd.Context(), path, pipelineOpts)
-			if err != nil {
-				return errCannotRun(err)
-			}
-
-			// --report writes to a file (or "-" = stdout).
-			if reportFmt != "" {
-				if err := writeReport(rpt, reportFmt, outPath, stdout); err != nil {
-					return errCannotRun(err)
-				}
-			} else if asJSON {
-				enc := json.NewEncoder(stdout)
-				enc.SetIndent("", "  ")
-				if err := enc.Encode(rpt); err != nil {
-					return errCannotRun(err)
-				}
-			} else if !quiet {
-				writeBriefText(stdout, rpt)
-			}
-
-			// --fail-below gating: exit 1 if level is below the floor.
-			if failBelow > 0 && int(rpt.Verdict.Level) < failBelow {
-				return &exitError{
-					code: exitGateFailed,
-					err:  fmt.Errorf("verdict level %d is below --fail-below %d", rpt.Verdict.Level, failBelow),
-				}
-			}
-			return nil
-		},
+		RunE: makeAssessRunE(flags, stdout, stderr),
 	}
-
-	f := cmd.Flags()
-	f.BoolVar(&asJSON, "json", false, "Emit JSON to stdout. Implies --cli. Schema: 'plumbline schema verdict'.")
-	f.StringVar(&reportFmt, "report", "", "Write a report file. fmt: markdown|json|sarif. Implies --cli.")
-	f.StringVar(&outPath, "out", "-", "Report destination. \"-\" = stdout.")
-	f.StringVar(&eventsFmt, "events", "", "Stream progress events to stderr. fmt: ndjson|text. Schema: 'plumbline schema event'.")
-	f.BoolVarP(&quiet, "quiet", "q", false, "Suppress banners, progress, and trailing hints. Implies --cli.")
-	f.BoolVar(&noColor, "no-color", false, "Disable ANSI color (also via NO_COLOR=1).")
-	f.BoolVar(&cli, "cli", false, "Force pure-CLI mode. Auto-set when stdout is not a TTY.")
-	f.BoolVar(&forceTUI, "tui", false, "Force TUI even when stdout is not a TTY.")
-	f.IntVar(&failBelow, "fail-below", 0, "Exit 1 if assessed level < N (2-5). 0 = no gate.")
-	f.StringVar(&profile, "profile", "default", "Named signal preset. See 'plumbline help profiles'.")
-	f.StringVar(&configPath, "config", "", "Override config path. Default: .plumbline.yml.")
-	f.StringVar(&minConfidence, "min-confidence", "low", "Minimum confidence to credit a signal: low|medium|high.")
-	f.StringVar(&signalSet, "signal-set", "latest", "Pin signal rule-set version (e.g., v1).")
-	f.StringVar(&ciSystem, "ci-system", "auto", "CI flavor: auto|github-actions. Other systems are M4+.")
-	f.BoolVar(&debug, "debug", false, "Emit detection diagnostics on stderr. Implies --cli.")
-	f.StringVar(&clock, "clock", "wall", "Timestamp source for events: wall|fixed|relative.")
-	f.StringSliceVar(&includeSignal, "include-signal", nil, "Only run the listed signals. Repeatable.")
-	f.StringSliceVar(&excludeSignal, "exclude-signal", nil, "Skip the listed signals. Repeatable.")
-	f.IntSliceVar(&levelFilters, "level", nil, "Only run signals at level N (2-5). Repeatable.")
-	f.StringSliceVar(&familyFilters, "family", nil, "Only run signals in family <name>. Repeatable.")
-
+	bindAssessFlags(cmd, flags)
 	return cmd
 }
 
@@ -383,8 +407,7 @@ func parseConfidence(s string) (acmm.Confidence, error) {
 	}
 }
 
-// writeBriefText prints a one-screen summary of the verdict. The richer
-// layout (level bars, next-gap panel) lands in a follow-up PR.
+// writeBriefText prints a one-screen summary of the verdict.
 func writeBriefText(w io.Writer, r acmm.Report) {
 	fmt.Fprintf(w, "plumbline · %s\n", r.Repo)
 	fmt.Fprintf(w, "Assessed level: %d (%s)\n\n", r.Verdict.Level, r.Verdict.Name)

--- a/cmd/plumbline/main.go
+++ b/cmd/plumbline/main.go
@@ -66,8 +66,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 }
 
 func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
+	// The root command is also the default action: `plumbline [path]`
+	// (no subcommand) runs the assess pipeline. It binds the same flag
+	// set as the assess subcommand so 'plumbline --json /repo' and
+	// 'plumbline assess --json /repo' are interchangeable.
+	rootFlags := &assessFlags{}
+
 	root := &cobra.Command{
-		Use:   "plumbline",
+		Use:   "plumbline [path]",
 		Short: "Repo-level AI coding readiness assessment based on the ACMM",
 		Long: `plumbline assesses a repository's AI Codebase Maturity Model (ACMM) level
 by detecting feedback-loop artifacts on disk. It runs deterministic checks —
@@ -78,10 +84,21 @@ Two interfaces at full feature parity:
   • Interactive TUI (Bubble Tea) — default when stdout is a TTY
   • Pure CLI — flag-driven, for LLM tool callers and CI gates
 
-Run 'plumbline help' for topical guides, or '<command> --help' for flags.`,
+Bare invocation runs the unified scan + score + report pipeline:
+  plumbline                # scan ".", TUI on a terminal / brief text otherwise
+  plumbline /path/to/repo  # scan a specific repo
+  plumbline --json         # machine-readable verdict
+  plumbline --fail-below 3 # CI gate
+
+This is the same pipeline as 'plumbline assess'. Use the subcommands
+below for narrower operations (inspect a single signal, list signals,
+publish schemas, etc.). Run 'plumbline help' for topical guides.`,
+		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true, // don't dump usage on every error
 		SilenceErrors: true, // we print errors ourselves with the right stream
+		RunE:          makeAssessRunE(rootFlags, stdout, stderr),
 	}
+	bindAssessFlags(root, rootFlags)
 
 	// Replace cobra's built-in `help` command with our topic-help command.
 	root.SetHelpCommand(newHelpCmd(stdout))

--- a/cmd/plumbline/main_test.go
+++ b/cmd/plumbline/main_test.go
@@ -14,16 +14,20 @@ func runCLI(t *testing.T, args ...string) (int, string, string) {
 	return code, stdout.String(), stderr.String()
 }
 
-func TestRoot_NoArgsShowsHelp(t *testing.T) {
-	code, out, _ := runCLI(t)
+// TestRoot_HelpFlagShowsUnifiedDescription — bare 'plumbline' now runs
+// the assess pipeline (see TestRoot_BareInvocationEmitsBriefText), so
+// the explicit way to get the help screen is `plumbline --help`. That
+// page still has to mention the description and the subcommand list.
+func TestRoot_HelpFlagShowsUnifiedDescription(t *testing.T) {
+	code, out, _ := runCLI(t, "--help")
 	if code != exitOK {
 		t.Fatalf("expected exit %d, got %d", exitOK, code)
 	}
 	if !strings.Contains(out, "plumbline assesses") {
-		t.Errorf("root help missing long-description marker; got:\n%s", out)
+		t.Errorf("root --help missing long-description marker; got:\n%s", out)
 	}
 	if !strings.Contains(out, "Available Commands") {
-		t.Errorf("root help missing command list; got:\n%s", out)
+		t.Errorf("root --help missing command list; got:\n%s", out)
 	}
 }
 
@@ -133,9 +137,14 @@ func TestAssess_FlagValidation(t *testing.T) {
 	}
 }
 
-func TestUnknownCommand_ExitsConfigError(t *testing.T) {
-	code, _, _ := runCLI(t, "definitely-not-a-command")
+// TestUnknownFlag_ExitsConfigError — with the unified default action,
+// any non-flag positional that isn't a registered subcommand is treated
+// as a path argument (and falls through to assess, exiting 2 if the
+// path is bogus). The "unknown command" case therefore no longer
+// applies; the meaningful CLI-validation error is an unknown flag.
+func TestUnknownFlag_ExitsConfigError(t *testing.T) {
+	code, _, _ := runCLI(t, "--definitely-not-a-flag")
 	if code != exitConfigError {
-		t.Errorf("expected exit %d for unknown command, got %d", exitConfigError, code)
+		t.Errorf("expected exit %d for unknown flag, got %d", exitConfigError, code)
 	}
 }

--- a/cmd/plumbline/root_default_test.go
+++ b/cmd/plumbline/root_default_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// TestRoot_NoSubcommandRunsAssess verifies that `plumbline [path]` (no
+// explicit subcommand) drives the assess pipeline — the unified
+// interface that runs scan + score + report all at once.
+func TestRoot_NoSubcommandRunsAssess(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CLAUDE.md", substantiveClaudeMD())
+
+	// Bare-invocation form: the path is the only positional arg, no
+	// "assess" keyword. --json forces CLI mode (avoiding the TUI).
+	code, out, errOut := runCLI(t, "--json", dir)
+	if code != exitOK {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errOut)
+	}
+	var report acmm.Report
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("bare invocation produced non-JSON stdout: %v\n%s", err, out)
+	}
+	if report.Schema != "plumbline/v1" {
+		t.Errorf("schema = %q, want plumbline/v1", report.Schema)
+	}
+	if report.Repo == "" {
+		t.Errorf("Repo field empty")
+	}
+}
+
+// TestRoot_BareInvocationEmitsBriefText verifies that `plumbline` with
+// no args and no --json (and no TTY in the test environment) prints
+// the brief text summary, not the cobra usage page.
+func TestRoot_BareInvocationEmitsBriefText(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CLAUDE.md", substantiveClaudeMD())
+
+	code, out, errOut := runCLI(t, "--cli", dir)
+	if code != exitOK {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errOut)
+	}
+	for _, want := range []string{"plumbline ·", "Assessed level:", "L2 Instructed"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bare invocation stdout missing %q. Got:\n%s", want, out)
+		}
+	}
+}
+
+// TestRoot_SubcommandsStillWork ensures adding a default action to the
+// root doesn't shadow the explicit subcommands.
+func TestRoot_SubcommandsStillWork(t *testing.T) {
+	for _, args := range [][]string{
+		{"signals", "--json"},
+		{"version"},
+		{"help"},
+		{"explain", "l2.claude-md"},
+	} {
+		args := args
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			code, _, errOut := runCLI(t, args...)
+			if code != exitOK {
+				t.Errorf("exit = %d, want 0 for %v (stderr: %s)", code, args, errOut)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Running \`plumbline [path]\` with no subcommand now runs the full scan + score + report pipeline — the same as \`plumbline assess [path]\`. On a TTY this opens the Bubble Tea interface; piped or in CI it emits brief text (or \`--json\` / \`--report\` output if requested).

## What changes

- \`plumbline\` (no args) → scans \`.\`, opens TUI on terminal / brief text otherwise
- \`plumbline /path/to/repo\` → scans that path
- \`plumbline --json\` → JSON verdict
- \`plumbline --fail-below 3\` → CI gate
- \`plumbline assess ...\` → still works (unchanged)
- \`plumbline signals\` / \`inspect\` / \`explain\` / \`schema\` / \`help\` / \`version\` → still route correctly

## Why
You asked for "a unified interface that runs all the processes all at once" when invoking the binary with no features. The assess pipeline already does scan + signals + scoring + report; this PR makes that the default for bare invocations.

## Implementation
- Extracted \`assessFlags\` + \`bindAssessFlags\` + \`makeAssessRunE\` so the flag set and run logic can attach to any cobra command.
- Root command and the \`assess\` subcommand both bind the same flag set and share the same RunE. Cobra's subcommand routing still wins for known subcommand names.

## Tests added
- \`TestRoot_NoSubcommandRunsAssess\` — bare \`--json /tempdir\` emits a valid Report
- \`TestRoot_BareInvocationEmitsBriefText\` — \`--cli\` mode prints the brief level summary, not cobra's help
- \`TestRoot_SubcommandsStillWork\` — \`signals\`/\`version\`/\`help\`/\`explain\` continue to route correctly

Two existing tests adjusted because the bare invocation no longer prints help (use \`plumbline --help\` for that) and unknown positionals are now treated as paths.

## Test plan
- [ ] \`make test\`
- [ ] \`./plumbline\` opens the TUI
- [ ] \`./plumbline --json | jq .verdict.level\` emits a number
- [ ] \`./plumbline --help\` shows the unified description
- [ ] \`./plumbline assess\` still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)