### PR TITLE
fix: detail view wraps text, explains why, and shows how to fix

### DIFF
--- a/cmd/plumbline/assess.go
+++ b/cmd/plumbline/assess.go
@@ -300,6 +300,7 @@ func runAssess(ctx context.Context, path string, opts pipelineOptions) (acmm.Rep
 			Method:     r.Method,
 			Evidence:   r.Evidence,
 			Notes:      r.Notes,
+			FixHint:    r.FixHint,
 			Diag:       r.Diag,
 		}
 		results = append(results, entry)

--- a/cmd/plumbline/inspect.go
+++ b/cmd/plumbline/inspect.go
@@ -11,8 +11,16 @@ import (
 
 	"github.com/sroberts/plumbline/internal/scanner"
 	"github.com/sroberts/plumbline/internal/signals"
+	"github.com/sroberts/plumbline/internal/textwrap"
 	"github.com/sroberts/plumbline/pkg/acmm"
 )
+
+// indentWrap word-wraps s and indents each line with prefix. Used for
+// the inspect output so long Notes / Excerpts / FixHints don't run off
+// the right edge.
+func indentWrap(prefix, s string, width int) string {
+	return textwrap.Indent(prefix, s, width)
+}
 
 func newInspectCmd(stdout, stderr io.Writer) *cobra.Command {
 	var (
@@ -96,6 +104,7 @@ See also:
 				Method:     result.Method,
 				Evidence:   result.Evidence,
 				Notes:      result.Notes,
+				FixHint:    result.FixHint,
 				Diag:       result.Diag,
 			}
 
@@ -122,27 +131,32 @@ func writeInspectText(w io.Writer, r acmm.SignalResult, repoPath string) {
 	fmt.Fprintf(w, "Family:      %s\n", r.Family)
 	fmt.Fprintf(w, "Status:      %s   (score=%v  confidence=%s  method=%s)\n",
 		r.Status, r.Score, r.Confidence, r.Method)
-	fmt.Fprintln(w)
 
+	if len(r.Notes) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Why:")
+		for _, n := range r.Notes {
+			fmt.Fprintln(w, indentWrap("  ", n, 76))
+		}
+	}
+
+	fmt.Fprintln(w)
 	if len(r.Evidence) == 0 {
 		fmt.Fprintln(w, "Evidence: (none)")
 	} else {
 		fmt.Fprintln(w, "Evidence:")
 		for _, e := range r.Evidence {
+			fmt.Fprintf(w, "  %s\n", e.Path)
 			if e.Excerpt != "" {
-				fmt.Fprintf(w, "  %s\n    %q\n", e.Path, e.Excerpt)
-			} else {
-				fmt.Fprintf(w, "  %s\n", e.Path)
+				fmt.Fprintln(w, indentWrap("    ", e.Excerpt, 76))
 			}
 		}
 	}
 
-	if len(r.Notes) > 0 {
+	if r.FixHint != "" {
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Notes:")
-		for _, n := range r.Notes {
-			fmt.Fprintf(w, "  %s\n", n)
-		}
+		fmt.Fprintln(w, "Fix:")
+		fmt.Fprintln(w, indentWrap("  ", r.FixHint, 76))
 	}
 
 	fmt.Fprintln(w)

--- a/cmd/plumbline/schema.go
+++ b/cmd/plumbline/schema.go
@@ -126,6 +126,7 @@ const schemaSignalResult = `{
       }
     },
     "notes": { "type": "array", "items": { "type": "string" } },
+    "fix_hint": { "type": "string", "description": "Short prose recipe for how to move this signal toward Found." },
     "diag": {
       "type": "array",
       "items": {

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -42,8 +42,16 @@ func Markdown(r acmm.Report) []byte {
 
 	if len(r.Verdict.NextGap) > 0 {
 		fmt.Fprintf(&buf, "## Next-level gap (to reach L%d)\n\n", r.Verdict.Level+1)
+		gapByID := make(map[string]acmm.SignalResult)
+		for _, s := range r.Signals {
+			gapByID[s.ID] = s
+		}
 		for _, id := range r.Verdict.NextGap {
-			fmt.Fprintf(&buf, "- [ ] `%s`\n", id)
+			s := gapByID[id]
+			fmt.Fprintf(&buf, "- [ ] `%s` — %s\n", id, s.Title)
+			if s.FixHint != "" {
+				fmt.Fprintf(&buf, "  - Fix: %s\n", s.FixHint)
+			}
 		}
 		fmt.Fprintln(&buf)
 	}

--- a/internal/signals/l2/claude_md.go
+++ b/internal/signals/l2/claude_md.go
@@ -1,11 +1,9 @@
-// Package l2 holds Level 2 (Instructed) signals — encoded preferences
-// in instruction files that AI agents consume at the start of every
-// session. See SPEC.md §6.
 package l2
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 
 	"github.com/sroberts/plumbline/internal/scanner"
@@ -13,11 +11,7 @@ import (
 	"github.com/sroberts/plumbline/pkg/acmm"
 )
 
-// claudeMDPath is the file the signal looks for at the repo root.
 const claudeMDPath = "CLAUDE.md"
-
-// claudeMDLineThreshold is the bar for "substantive" content. Below it,
-// the file is treated as a stub even when it has a heading.
 const claudeMDLineThreshold = 30
 
 // ClaudeMD detects whether a substantive CLAUDE.md exists at the repo
@@ -33,23 +27,22 @@ func (ClaudeMD) Title() string     { return "CLAUDE.md present and substantive" 
 func (s ClaudeMD) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result {
 	data, err := idx.Read(claudeMDPath)
 	if err != nil {
-		// File-not-found is the expected Missing case; any other error
-		// is also Missing for now (signals don't propagate errors —
-		// the verdict caller cannot do anything with them).
-		if errors.Is(err, fs.ErrNotExist) {
-			return acmm.Result{
-				Status:     acmm.StatusMissing,
-				Score:      acmm.ScoreMissing,
-				Confidence: acmm.ConfidenceHigh,
-				Method:     acmm.MethodContentRegex,
-			}
+		notes := []string{}
+		if !errors.Is(err, fs.ErrNotExist) {
+			notes = append(notes, "could not read CLAUDE.md: "+err.Error())
+		} else {
+			notes = append(notes, "no CLAUDE.md at repo root")
 		}
 		return acmm.Result{
 			Status:     acmm.StatusMissing,
 			Score:      acmm.ScoreMissing,
 			Confidence: acmm.ConfidenceHigh,
 			Method:     acmm.MethodContentRegex,
-			Notes:      []string{"could not read CLAUDE.md: " + err.Error()},
+			Notes:      notes,
+			FixHint: "Create a CLAUDE.md at the repo root with at least one " +
+				"heading and ~30 lines of guidance covering the project's " +
+				"conventions, architecture, and the kinds of changes you " +
+				"want AI agents to avoid.",
 		}
 	}
 
@@ -65,7 +58,7 @@ func (s ClaudeMD) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result 
 		score = acmm.ScoreIncomplete
 	}
 
-	return acmm.Result{
+	res := acmm.Result{
 		Status:     acmm.StatusFromScore(score),
 		Score:      score,
 		Confidence: acmm.ConfidenceMedium,
@@ -75,6 +68,30 @@ func (s ClaudeMD) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result 
 			Excerpt: excerpt(data, 160),
 		}},
 	}
+
+	if score == acmm.ScoreFound {
+		res.Notes = []string{fmt.Sprintf("heading present and %d non-blank lines (≥%d)", nonBlank, claudeMDLineThreshold)}
+		return res
+	}
+
+	// Partial — explain why and offer a fix.
+	if !hasHeading {
+		res.Notes = append(res.Notes, "no markdown heading (a line starting with '#') detected")
+	}
+	if !hasBody {
+		res.Notes = append(res.Notes, fmt.Sprintf("only %d non-blank lines (need ≥%d for Found)", nonBlank, claudeMDLineThreshold))
+	}
+	switch {
+	case !hasHeading && !hasBody:
+		res.FixHint = "Add a markdown heading (e.g. '# CLAUDE.md') and " +
+			"flesh out the file with at least ~30 lines of project " +
+			"conventions and rules."
+	case !hasHeading:
+		res.FixHint = "Add a top-level markdown heading (e.g. '# CLAUDE.md') so the file is parseable as a structured guide."
+	case !hasBody:
+		res.FixHint = fmt.Sprintf("Expand CLAUDE.md from %d to ≥%d non-blank lines. Cover conventions, architecture, common pitfalls, and what *not* to do.", nonBlank, claudeMDLineThreshold)
+	}
+	return res
 }
 
 func init() {

--- a/internal/signals/l2/commit_rules.go
+++ b/internal/signals/l2/commit_rules.go
@@ -75,6 +75,12 @@ func (s CommitRules) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Resu
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceHigh,
 		Method:     acmm.MethodFilenameMatch,
+		Notes:      []string{"no .gitmessage, commitlint config, or commit-convention.md found"},
+		FixHint: "Pick one: (a) commit a .gitmessage template (and 'git config " +
+			"commit.template .gitmessage'), (b) add a commitlint.config.js " +
+			"with @commitlint/config-conventional, or (c) write a brief " +
+			".github/commit-convention.md describing your prefix vocabulary " +
+			"(feat:, fix:, etc.).",
 	}
 }
 

--- a/internal/signals/l2/contributor_guide.go
+++ b/internal/signals/l2/contributor_guide.go
@@ -69,6 +69,11 @@ func (s ContributorGuide) Detect(_ context.Context, idx *scanner.RepoIndex) acmm
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceHigh,
 		Method:     acmm.MethodFilenameMatch,
+		Notes:      []string{"no CONTRIBUTING.md or equivalent contributor guide at known paths"},
+		FixHint: "Add CONTRIBUTING.md (or .github/CONTRIBUTING.md) covering " +
+			"how PRs are reviewed, what counts as a 'good' change, and the " +
+			"common rejection reasons. Aim for ≥20 substantive lines under " +
+			"at least one heading.",
 	}
 }
 

--- a/internal/signals/l2/copilot_instructions.go
+++ b/internal/signals/l2/copilot_instructions.go
@@ -3,6 +3,7 @@ package l2
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 
 	"github.com/sroberts/plumbline/internal/scanner"
@@ -15,10 +16,6 @@ const (
 	copilotLineThreshold = 20
 )
 
-// CopilotInstructions detects whether .github/copilot-instructions.md
-// exists with a heading and at least 20 non-blank lines. The same
-// rubric shape as ClaudeMD; just a lower line bar because Copilot
-// instructions tend to be shorter.
 type CopilotInstructions struct{}
 
 func (CopilotInstructions) ID() string        { return "l2.copilot-instructions" }
@@ -31,25 +28,28 @@ func (CopilotInstructions) Title() string {
 func (s CopilotInstructions) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result {
 	data, err := idx.Read(copilotPath)
 	if err != nil {
+		notes := []string{}
 		if errors.Is(err, fs.ErrNotExist) {
-			return acmm.Result{
-				Status:     acmm.StatusMissing,
-				Score:      acmm.ScoreMissing,
-				Confidence: acmm.ConfidenceHigh,
-				Method:     acmm.MethodContentRegex,
-			}
+			notes = append(notes, "no .github/copilot-instructions.md found")
+		} else {
+			notes = append(notes, "could not read "+copilotPath+": "+err.Error())
 		}
 		return acmm.Result{
 			Status:     acmm.StatusMissing,
 			Score:      acmm.ScoreMissing,
 			Confidence: acmm.ConfidenceHigh,
 			Method:     acmm.MethodContentRegex,
-			Notes:      []string{"could not read " + copilotPath + ": " + err.Error()},
+			Notes:      notes,
+			FixHint: "Create .github/copilot-instructions.md describing your " +
+				"team's conventions: tech stack, patterns to follow, anti-" +
+				"patterns to avoid. Aim for ≥20 substantive lines under at " +
+				"least one heading.",
 		}
 	}
 
 	hasHeading := containsHeading(data)
-	hasBody := countNonBlankLines(data) >= copilotLineThreshold
+	nonBlank := countNonBlankLines(data)
+	hasBody := nonBlank >= copilotLineThreshold
 
 	score := acmm.ScoreStubbed
 	switch {
@@ -59,7 +59,7 @@ func (s CopilotInstructions) Detect(_ context.Context, idx *scanner.RepoIndex) a
 		score = acmm.ScoreIncomplete
 	}
 
-	return acmm.Result{
+	res := acmm.Result{
 		Status:     acmm.StatusFromScore(score),
 		Score:      score,
 		Confidence: acmm.ConfidenceMedium,
@@ -69,6 +69,27 @@ func (s CopilotInstructions) Detect(_ context.Context, idx *scanner.RepoIndex) a
 			Excerpt: excerpt(data, 160),
 		}},
 	}
+
+	if score == acmm.ScoreFound {
+		res.Notes = []string{fmt.Sprintf("heading present and %d non-blank lines (≥%d)", nonBlank, copilotLineThreshold)}
+		return res
+	}
+
+	if !hasHeading {
+		res.Notes = append(res.Notes, "no markdown heading detected")
+	}
+	if !hasBody {
+		res.Notes = append(res.Notes, fmt.Sprintf("only %d non-blank lines (need ≥%d for Found)", nonBlank, copilotLineThreshold))
+	}
+	switch {
+	case !hasHeading && !hasBody:
+		res.FixHint = "Add a heading and expand the file with concrete conventions; the current content is too short to function as guidance."
+	case !hasHeading:
+		res.FixHint = "Add a top-level markdown heading at the start of the file."
+	case !hasBody:
+		res.FixHint = fmt.Sprintf("Expand the file from %d to ≥%d non-blank lines covering your team's conventions and gotchas.", nonBlank, copilotLineThreshold)
+	}
+	return res
 }
 
 func init() {

--- a/internal/signals/l2/fixhint_test.go
+++ b/internal/signals/l2/fixhint_test.go
@@ -1,0 +1,65 @@
+package l2
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// TestClaudeMD_PartialPopulatesFixAndNotes — partial verdicts must
+// surface (a) why they're partial in Notes and (b) a fix recipe in
+// FixHint, so the TUI / inspect / markdown can show "here's what's
+// missing and here's how to fix it."
+func TestClaudeMD_PartialPopulatesFixAndNotes(t *testing.T) {
+	// 5 lines + heading = incomplete (heading present, body too short).
+	files := fstest.MapFS{
+		"CLAUDE.md": {Data: []byte("# CLAUDE.md\n\nshort.\n")},
+	}
+	got := runSignal(t, ClaudeMD{}, files)
+	if got.FixHint == "" {
+		t.Errorf("partial result has empty FixHint; need a recipe to display")
+	}
+	if len(got.Notes) == 0 {
+		t.Errorf("partial result has empty Notes; need a 'why' explanation")
+	}
+	// The Notes should mention the line count or threshold.
+	joined := strings.Join(got.Notes, " ")
+	if !strings.Contains(joined, "30") && !strings.Contains(joined, "non-blank") {
+		t.Errorf("Notes do not explain why this is partial; got: %v", got.Notes)
+	}
+}
+
+func TestCopilotInstructions_PartialPopulatesFixAndNotes(t *testing.T) {
+	// Heading present, fewer than 20 non-blank lines → incomplete.
+	files := fstest.MapFS{
+		".github/copilot-instructions.md": {Data: []byte("# Copilot\n\nshort.\n")},
+	}
+	got := runSignal(t, CopilotInstructions{}, files)
+	if got.FixHint == "" {
+		t.Errorf("partial copilot-instructions has empty FixHint")
+	}
+	if len(got.Notes) == 0 {
+		t.Errorf("partial copilot-instructions has empty Notes")
+	}
+}
+
+func TestPRTemplate_MissingPopulatesFix(t *testing.T) {
+	got := runSignal(t, PRTemplate{}, fstest.MapFS{})
+	if got.FixHint == "" {
+		t.Errorf("missing PR template has empty FixHint; user has nothing to act on")
+	}
+}
+
+func TestCommitRules_MissingPopulatesFix(t *testing.T) {
+	got := runSignal(t, CommitRules{}, fstest.MapFS{})
+	if got.FixHint == "" {
+		t.Errorf("missing commit-rules has empty FixHint")
+	}
+}
+
+func TestContributorGuide_MissingPopulatesFix(t *testing.T) {
+	got := runSignal(t, ContributorGuide{}, fstest.MapFS{})
+	if got.FixHint == "" {
+		t.Errorf("missing contributor-guide has empty FixHint")
+	}
+}

--- a/internal/signals/l2/pr_template.go
+++ b/internal/signals/l2/pr_template.go
@@ -3,6 +3,7 @@ package l2
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 
 	"github.com/sroberts/plumbline/internal/scanner"
@@ -68,6 +69,10 @@ func (s PRTemplate) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Resul
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceHigh,
 		Method:     acmm.MethodFilenameMatch,
+		Notes:      []string{"no PR template found at .github/pull_request_template.md or PULL_REQUEST_TEMPLATE/"},
+		FixHint: "Add .github/pull_request_template.md with at least 3 markdown " +
+			"checkboxes ('- [ ] item') so AI agents fill in a structured " +
+			"checklist on every PR.",
 	}
 }
 
@@ -80,7 +85,7 @@ func scorePRTemplate(path string, data []byte) acmm.Result {
 	case checkboxes >= prTemplateSomeCheckboxes:
 		score = acmm.ScoreIncomplete
 	}
-	return acmm.Result{
+	res := acmm.Result{
 		Status:     acmm.StatusFromScore(score),
 		Score:      score,
 		Confidence: acmm.ConfidenceMedium,
@@ -90,6 +95,18 @@ func scorePRTemplate(path string, data []byte) acmm.Result {
 			Excerpt: excerpt(data, 160),
 		}},
 	}
+	switch {
+	case score == acmm.ScoreFound:
+		res.Notes = []string{fmt.Sprintf("%d markdown checkboxes (≥%d)", checkboxes, prTemplateMinCheckboxes)}
+	case score == acmm.ScoreIncomplete:
+		res.Notes = []string{fmt.Sprintf("only %d markdown checkboxes (need ≥%d for Found)", checkboxes, prTemplateMinCheckboxes)}
+		res.FixHint = fmt.Sprintf("Add %d more markdown checkbox(es) to the PR template covering pre-merge checks (tests, docs, version bumps, etc.).",
+			prTemplateMinCheckboxes-checkboxes)
+	default:
+		res.Notes = []string{"PR template exists but has no markdown checkboxes"}
+		res.FixHint = "Add at least 3 markdown checkboxes ('- [ ] tests added', etc.) to make the template actionable for AI agents."
+	}
+	return res
 }
 
 func startsWith(s, prefix string) bool {

--- a/internal/signals/l3/acceptance_tracking.go
+++ b/internal/signals/l3/acceptance_tracking.go
@@ -46,6 +46,11 @@ func (s AcceptanceTracking) Detect(_ context.Context, idx *scanner.RepoIndex) ac
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodFilenameMatch,
+		Notes:      []string{"no auto-qa-tuning.json / acceptance-rates.* or metrics/* file found"},
+		FixHint: "Track AI agent acceptance rates: commit " +
+			"auto-qa-tuning.json (or acceptance-rates.json) and update it " +
+			"from a scheduled job that classifies merged-vs-rejected PRs by " +
+			"category. This is what L4 self-tuning consumes.",
 	}
 }
 

--- a/internal/signals/l3/build_lint_gate.go
+++ b/internal/signals/l3/build_lint_gate.go
@@ -56,6 +56,10 @@ func (s BuildLintGate) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Re
 			Score:      acmm.ScoreMissing,
 			Confidence: acmm.ConfidenceMedium,
 			Method:     acmm.MethodAST,
+			Notes:      []string{"no push/PR-triggered workflow runs both build and lint"},
+			FixHint: "Add a CI workflow on push/pull_request that builds the " +
+				"project AND runs a linter (golangci-lint, eslint, etc.). " +
+				"Both steps gate every PR — it's the L3 baseline.",
 		}
 	}
 	return acmm.Result{
@@ -64,6 +68,8 @@ func (s BuildLintGate) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Re
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodAST,
 		Evidence:   []acmm.Evidence{{Path: bestPath}},
+		Notes:      []string{"workflow runs only one of build / lint"},
+		FixHint:    "Extend the existing CI workflow so it runs both a build step and a lint step on every push/PR.",
 	}
 }
 

--- a/internal/signals/l3/coverage_gate.go
+++ b/internal/signals/l3/coverage_gate.go
@@ -74,6 +74,11 @@ func (s CoverageGate) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Res
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodContentRegex,
+		Notes:      []string{"no codecov.yml target and no coverage threshold flag in any PR workflow"},
+		FixHint: "Either commit a codecov.yml with target.coverage (e.g. 80%), " +
+			"or add a coverage threshold flag to your test step " +
+			"(--cov-fail-under=80 for pytest, -coverpkg + threshold for go, etc.) " +
+			"so PRs that drop coverage actually fail.",
 	}
 }
 

--- a/internal/signals/l3/coverage_suite.go
+++ b/internal/signals/l3/coverage_suite.go
@@ -38,6 +38,10 @@ func (s CoverageSuite) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Re
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodAST,
+		Notes:      []string{"no scheduled (cron) workflow runs the coverage suite"},
+		FixHint: "Add a scheduled workflow (e.g. nightly cron) that runs your " +
+			"full coverage suite. The PR-time gate catches regressions; the " +
+			"scheduled run catches drift on slow-changing code paths.",
 	}
 }
 

--- a/internal/signals/l3/error_monitoring.go
+++ b/internal/signals/l3/error_monitoring.go
@@ -66,7 +66,13 @@ func (s ErrorMonitoring) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceLow,
 		Method:     acmm.MethodContentRegex,
-		Notes:      []string{"low confidence — only checks dependency manifests, not runtime config"},
+		Notes: []string{
+			"no Sentry / OpenTelemetry / Bugsnag / similar dependency found",
+			"low confidence — only checks dependency manifests, not runtime config",
+		},
+		FixHint: "Wire in an error-monitoring SDK (Sentry, OpenTelemetry, or " +
+			"equivalent). Without runtime error signals, AI agents can't " +
+			"distinguish 'this fix worked' from 'this fix silently broke prod.'",
 	}
 }
 

--- a/internal/signals/l3/flaky_analysis.go
+++ b/internal/signals/l3/flaky_analysis.go
@@ -50,6 +50,11 @@ func (s FlakyAnalysis) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Re
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodFilenameMatch,
+		Notes:      []string{"no flaky-tests.json or scheduled flaky-analysis workflow"},
+		FixHint: "Track flakes explicitly: commit a flaky-tests.json (or run a " +
+			"weekly workflow named 'flaky-*' that re-runs failing tests N " +
+			"times to identify intermittents). A flake in an autonomous AI " +
+			"loop is far more dangerous than in a human one.",
 	}
 }
 

--- a/internal/signals/l3/nightly_compliance.go
+++ b/internal/signals/l3/nightly_compliance.go
@@ -38,6 +38,10 @@ func (s NightlyCompliance) Detect(_ context.Context, idx *scanner.RepoIndex) acm
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodAST,
+		Notes:      []string{"no scheduled compliance / a11y / perf / security workflow detected"},
+		FixHint: "Add a nightly cron workflow named (or with a path containing) " +
+			"'nightly', 'compliance', 'a11y', 'perf', or 'security'. Use it " +
+			"to run the heavy checks that don't fit the per-PR latency budget.",
 	}
 }
 

--- a/internal/signals/l3/user_feedback.go
+++ b/internal/signals/l3/user_feedback.go
@@ -45,7 +45,14 @@ func (s UserFeedback) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Res
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceLow,
 		Method:     acmm.MethodFilenameMatch,
-		Notes:      []string{"low confidence — name match only"},
+		Notes: []string{
+			"no NPS / survey component or feedback issue template found",
+			"low confidence — name match only",
+		},
+		FixHint: "Add a lightweight user-feedback channel: an NPS / CSAT " +
+			"survey component (e.g. useNPSSurvey hook), or a " +
+			".github/ISSUE_TEMPLATE/feedback.md so users can report what " +
+			"shipped wrong.",
 	}
 }
 

--- a/internal/signals/l4/l4.go
+++ b/internal/signals/l4/l4.go
@@ -58,6 +58,8 @@ func (SelfModifyingConfig) Detect(_ context.Context, idx *scanner.RepoIndex) acm
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodAST,
+		Notes:      []string{"no workflow uses peter-evans/create-pull-request, git-auto-commit-action, or git push+commit from a step"},
+		FixHint:    "Add a workflow that, on a metric or schedule, opens a PR back to the repo (peter-evans/create-pull-request is the canonical action). This is the L4 unlock — humans go from execution to governance.",
 	}
 }
 
@@ -100,6 +102,8 @@ func (AutoTriage) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result 
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodAST,
+		Notes:      []string{"no sub-daily scheduled workflow that touches the GitHub Issues API"},
+		FixHint:    "Add a workflow on a sub-daily cron (e.g. '*/15 * * * *') that runs 'gh issue list' or hits /issues via actions/github-script and triages new issues automatically.",
 	}
 }
 
@@ -153,6 +157,8 @@ func (ThresholdBlock) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Res
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodContentRegex,
+		Notes:      []string{"no workflow has an `if:` conditional reading a metric and gating on a numeric threshold"},
+		FixHint:    "Add a step with `if: ${{ fromJson(steps.metrics.outputs.data).rate < 80 }}` (or similar) so the system blocks itself when a metric crosses a threshold. This is what closes the L4 loop.",
 	}
 }
 
@@ -212,6 +218,8 @@ func (WorktreeAgents) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Res
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceLow,
 		Method:     acmm.MethodFilenameMatch,
+		Notes:      []string{"no .devcontainer / .claude config / git-worktree scripts found"},
+		FixHint:    "Set up infrastructure for concurrent AI agent runs: a .devcontainer/ for reproducible environments, or a script under scripts/ that spawns isolated git worktrees so multiple agents can work in parallel without stepping on each other.",
 	}
 }
 
@@ -257,6 +265,8 @@ func (ErrorRecovery) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Resu
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodAST,
+		Notes:      []string{"no workflow uses nick-fields/retry or has continue-on-error: true"},
+		FixHint:    "Wrap flake-prone steps with nick-fields/retry@v3 (max_attempts: 3) so the autonomous loop doesn't fail on a transient hiccup. Use `continue-on-error: true` for non-blocking diagnostics.",
 	}
 }
 

--- a/internal/signals/l5/l5.go
+++ b/internal/signals/l5/l5.go
@@ -47,6 +47,8 @@ func (IssueToPR) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result {
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodAST,
+		Notes:      []string{"no workflow with issues:[opened|labeled] trigger that opens a PR"},
+		FixHint:    "Wire issues to PRs: a workflow on `issues: [opened, labeled]` that calls a fix-generating script (or hands the issue to an AI agent) and then opens a PR via peter-evans/create-pull-request. This is the L5 unlock — community steers, AI implements.",
 	}
 }
 
@@ -94,6 +96,8 @@ func (SelfImprovement) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Re
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodContentRegex,
+		Notes:      []string{"no on-PR-close workflow rewrites CLAUDE.md / copilot-instructions / equivalent"},
+		FixHint:    "Add a workflow on `pull_request: types: [closed]` that analyzes merged PRs and proposes updates to your instruction files (CLAUDE.md, copilot-instructions.md). The codebase teaches itself.",
 	}
 }
 
@@ -131,6 +135,8 @@ func (DocsFromPRs) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodContentRegex,
+		Notes:      []string{"no PR-triggered workflow updates docs/ / web/docs / README"},
+		FixHint:    "Add a workflow on PR events that regenerates docs/ from the change set (e.g. screenshots, API tables, CHANGELOG entries) and either commits to the branch or opens a docs PR via peter-evans/create-pull-request.",
 	}
 }
 
@@ -167,6 +173,8 @@ func (MultiRepoOrchestration) Detect(_ context.Context, idx *scanner.RepoIndex) 
 		Score:      acmm.ScoreMissing,
 		Confidence: acmm.ConfidenceMedium,
 		Method:     acmm.MethodContentRegex,
+		Notes:      []string{"no workflow uses `gh api repos/<other>/...` or matrixes over multiple repos"},
+		FixHint:    "Add a workflow that fans out across your other repos (via `gh api repos/<owner>/<other>/...` calls or a matrix that varies a 'repo' dimension). L5 systems coordinate at the org level, not per-repo.",
 	}
 }
 

--- a/internal/textwrap/textwrap.go
+++ b/internal/textwrap/textwrap.go
@@ -1,0 +1,69 @@
+// Package textwrap is a small word-wrap helper shared by the CLI
+// inspect formatter and the Bubble Tea TUI detail view. It is
+// deliberately ASCII-oriented and stdlib-only — no extra dependency
+// just to wrap a paragraph.
+package textwrap
+
+import "strings"
+
+// Wrap word-wraps s to width columns, preserving any explicit newlines
+// already present. Words longer than width are emitted on their own
+// line rather than mid-word split (matches what humans expect when
+// inspecting code paths or URLs).
+func Wrap(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	var out strings.Builder
+	for i, line := range strings.Split(s, "\n") {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		wrapLine(&out, line, width)
+	}
+	return out.String()
+}
+
+// Indent prefixes every line of s with prefix, then word-wraps the
+// result so each output line fits in width columns *including* the
+// prefix.
+func Indent(prefix, s string, width int) string {
+	body := Wrap(s, width-len(prefix))
+	var out strings.Builder
+	for i, line := range strings.Split(body, "\n") {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(prefix)
+		out.WriteString(line)
+	}
+	return out.String()
+}
+
+func wrapLine(w *strings.Builder, line string, width int) {
+	if len(line) <= width {
+		w.WriteString(line)
+		return
+	}
+	words := strings.Fields(line)
+	if len(words) == 0 {
+		// Whitespace-only line; preserve as empty.
+		return
+	}
+	pos := 0
+	for i, word := range words {
+		switch {
+		case i == 0:
+			w.WriteString(word)
+			pos = len(word)
+		case pos+1+len(word) > width:
+			w.WriteByte('\n')
+			w.WriteString(word)
+			pos = len(word)
+		default:
+			w.WriteByte(' ')
+			w.WriteString(word)
+			pos += 1 + len(word)
+		}
+	}
+}

--- a/internal/textwrap/textwrap_test.go
+++ b/internal/textwrap/textwrap_test.go
@@ -1,0 +1,53 @@
+package textwrap
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWrap_ShortLineUntouched(t *testing.T) {
+	got := Wrap("hello world", 80)
+	if got != "hello world" {
+		t.Errorf("Wrap = %q, want %q", got, "hello world")
+	}
+}
+
+func TestWrap_LongLineWraps(t *testing.T) {
+	in := "alpha bravo charlie delta echo foxtrot golf"
+	got := Wrap(in, 20)
+	for _, line := range strings.Split(got, "\n") {
+		if len(line) > 20 {
+			t.Errorf("line too long (%d > 20): %q", len(line), line)
+		}
+	}
+	// Ensure no words got split.
+	if strings.Contains(got, "char-") || strings.Contains(got, "fox-") {
+		t.Errorf("Wrap split a word; output:\n%s", got)
+	}
+}
+
+func TestWrap_PreservesExistingNewlines(t *testing.T) {
+	in := "line one\n\nline two"
+	got := Wrap(in, 80)
+	if got != in {
+		t.Errorf("Wrap mangled newlines: got %q, want %q", got, in)
+	}
+}
+
+func TestWrap_ZeroWidthReturnsInput(t *testing.T) {
+	if got := Wrap("abc def", 0); got != "abc def" {
+		t.Errorf("zero width should return input unchanged; got %q", got)
+	}
+}
+
+func TestIndent_PrefixesEveryLine(t *testing.T) {
+	got := Indent("> ", "alpha bravo charlie delta", 12)
+	for _, line := range strings.Split(got, "\n") {
+		if !strings.HasPrefix(line, "> ") {
+			t.Errorf("indented line missing prefix: %q", line)
+		}
+		if len(line) > 12 {
+			t.Errorf("indented line over width: %q (len=%d)", line, len(line))
+		}
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/sroberts/plumbline/internal/textwrap"
 	"github.com/sroberts/plumbline/pkg/acmm"
 )
 
@@ -225,10 +226,19 @@ func (m *model) renderDetail() string {
 		return ""
 	}
 	s := m.report.Signals[m.cursor]
+
+	// Compute the wrap width from the current viewport. Subtract a
+	// margin for the indent prefixes used inside each block.
+	wrapWidth := m.width
+	if wrapWidth <= 0 {
+		wrapWidth = 80
+	}
+	bodyWidth := wrapWidth - 2 // indent margin
+
 	var b strings.Builder
 	b.WriteString(styleHeader.Render(fmt.Sprintf("%s · %s", s.ID, statusStyle(s.Status).Render(string(s.Status)))))
 	b.WriteString("\n")
-	b.WriteString(strings.Repeat("─", 60))
+	b.WriteString(strings.Repeat("─", min(60, wrapWidth)))
 	b.WriteString("\n")
 	b.WriteString(fmt.Sprintf("Title:      %s\n", s.Title))
 	b.WriteString(fmt.Sprintf("Level:      %d (%s)\n", s.Level, s.Level.Name()))
@@ -238,6 +248,18 @@ func (m *model) renderDetail() string {
 	b.WriteString(fmt.Sprintf("Method:     %s\n", s.Method))
 	b.WriteString("\n")
 
+	// "Why" block — Notes carry the rubric explanation. Surface this
+	// before Evidence so the user understands the verdict immediately.
+	if len(s.Notes) > 0 {
+		b.WriteString(styleHeader.Render("Why:"))
+		b.WriteString("\n")
+		for _, n := range s.Notes {
+			b.WriteString(textwrap.Indent("  · ", n, bodyWidth))
+			b.WriteByte('\n')
+		}
+		b.WriteString("\n")
+	}
+
 	if len(s.Evidence) == 0 {
 		b.WriteString(styleNA.Render("Evidence: (none)\n"))
 	} else {
@@ -246,21 +268,30 @@ func (m *model) renderDetail() string {
 		for _, e := range s.Evidence {
 			b.WriteString(fmt.Sprintf("  %s\n", e.Path))
 			if e.Excerpt != "" {
-				b.WriteString(fmt.Sprintf("    %s\n", styleNA.Render(e.Excerpt)))
+				b.WriteString(styleNA.Render(textwrap.Indent("    ", e.Excerpt, bodyWidth)))
+				b.WriteByte('\n')
 			}
 		}
 	}
 
-	if len(s.Notes) > 0 {
+	// "Fix" block — load-bearing. The user opened the detail screen
+	// because something is wrong; tell them how to fix it.
+	if s.FixHint != "" {
 		b.WriteString("\n")
-		b.WriteString(styleHeader.Render("Notes:"))
+		b.WriteString(styleHeader.Render("Fix:"))
 		b.WriteString("\n")
-		for _, n := range s.Notes {
-			b.WriteString(fmt.Sprintf("  %s\n", n))
-		}
+		b.WriteString(textwrap.Indent("  ", s.FixHint, bodyWidth))
+		b.WriteByte('\n')
 	}
 
 	b.WriteString("\n")
 	b.WriteString(styleHint.Render("[esc/enter] back   [q] quit"))
 	return b.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/pkg/acmm/types.go
+++ b/pkg/acmm/types.go
@@ -125,7 +125,11 @@ type DiagEntry struct {
 }
 
 // Result is what every signal returns. Score must come from the rubric
-// constants above; Status is derived from Score.
+// constants above; Status is derived from Score. FixHint is a short
+// human-readable recipe — what the user should do to move this signal
+// from Missing/Partial toward Found. Notes are the "why" — diagnostic
+// detail like "27 non-blank lines (need 30)" — populated mainly for
+// Partial results so the TUI / inspect can explain the verdict.
 type Result struct {
 	Status     Status      `json:"status"`
 	Score      float64     `json:"score"`
@@ -133,6 +137,7 @@ type Result struct {
 	Method     Method      `json:"method"`
 	Evidence   []Evidence  `json:"evidence,omitempty"`
 	Notes      []string    `json:"notes,omitempty"`
+	FixHint    string      `json:"fix_hint,omitempty"`
 	Diag       []DiagEntry `json:"diag,omitempty"`
 }
 
@@ -148,6 +153,7 @@ type SignalResult struct {
 	Method     Method      `json:"method"`
 	Evidence   []Evidence  `json:"evidence,omitempty"`
 	Notes      []string    `json:"notes,omitempty"`
+	FixHint    string      `json:"fix_hint,omitempty"`
 	Diag       []DiagEntry `json:"diag,omitempty"`
 }
 


### PR DESCRIPTION
## What you reported
Detail screen had three problems:
1. **No word-wrap** — long evidence excerpts ran off the right edge.
2. **Status wasn't shown fully** — numeric score/confidence/method, no narrative for *why* the verdict was partial.
3. **No fix suggestion** — nothing told you what to actually do.

## What changes

### \`pkg/acmm\`
- New \`Result.FixHint\` and \`SignalResult.FixHint\` — short prose recipe for moving a signal toward Found.
- JSON Schema for \`signal-result\` updated to expose \`fix_hint\`.

### \`internal/textwrap\`
- Tiny stdlib-only word-wrap helper used by both the CLI inspect formatter and the TUI detail view. Wraps without splitting words; preserves explicit newlines.

### Every signal (L2 / L3 / L4 / L5)
- **L2** signals populate \`Notes\` and \`FixHint\` for partial and missing cases with numbers from the rubric (e.g. "only 27 non-blank lines, need ≥30").
- **L3 / L4 / L5** missing branches each get a \`Notes\` line ("what's absent") and a \`FixHint\` with concrete next steps for that specific signal.

### TUI detail view
- Word-wraps to current viewport width.
- New 'Why:' block above Evidence — surfaces the rubric explanation.
- New 'Fix:' block at the bottom, prominent.

### CLI inspect
- Same 'Why:' / 'Fix:' structure, wrapped to 76 columns.

### Markdown report
- Each next-gap entry includes the signal title and an indented Fix: line.

## Before / after for \`./plumbline inspect l2.claude-md\` on this repo:

**Before:** Title, Score 0.67, Confidence medium, Method content-regex, Evidence \`# CLAUDE.md\`, excerpt cut off mid-word, nothing else.

**After:**
\`\`\`
l2.claude-md · CLAUDE.md present and substantive
Repo:        /Users/sroberts/Developer/plumbline
Level:       2 (Instructed)
Family:      instructions
Status:      partial   (score=0.67  confidence=medium  method=content-regex)

Why:
  only 27 non-blank lines (need ≥30 for Found)

Evidence:
  CLAUDE.md
    # CLAUDE.md
    
    This file provides guidance to Claude Code (claude.ai/code) when working
    with code in this repository.
    ...

Fix:
  Expand CLAUDE.md from 27 to ≥30 non-blank lines. Cover conventions,
  architecture, common pitfalls, and what *not* to do.
\`\`\`

## Test plan
- [ ] \`make test\`
- [ ] \`./plumbline inspect l2.claude-md\` — shows Why + Fix
- [ ] \`./plumbline assess --tui\` (or \`./plumbline\` after #5) → enter on a partial signal — wraps + shows Why + Fix
- [ ] \`./plumbline assess --json | jq '.signals[] | select(.fix_hint) | {id, fix_hint}'\` — fix hints populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)