### PR TITLE
chore: MIT LICENSE; correct arXiv source-paper note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,4 +42,4 @@ Two anti-patterns the assessor should also flag:
 ## Working norms specific to this repo
 
 - The paper's `.md` is a MarkItDown conversion of a PDF. Expect odd line wrapping, hyphenation across lines, and stray whitespace. Don't "tidy" it — it's the source artifact, and downstream parsing should be robust to it. Quote line ranges rather than reflowing.
-- The README claims an arXiv URL (`arxiv.org/abs/2604.09388v1`) and an author (Andy Anderson). Both appear to be fictional / illustrative for the paper's framing — don't try to fetch the arXiv page or cite the author as a real source when designing the tool.
+- The source paper is real: [arxiv.org/abs/2604.09388v1](https://arxiv.org/abs/2604.09388v1) ("The AI Codebase Maturity Model" by Andy Anderson, IBM Research). The local `the_ai_codebase_maturity_model.md` is the markdown conversion (via Microsoft MarkItDown) of the paper's PDF. Cite the arXiv URL when referencing claims; quote line ranges from the local `.md` when working with specific passages, since the conversion has whitespace/hyphenation quirks worth preserving.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Scott Roberts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -143,4 +143,8 @@ Stable IDs, stable JSON-Schema `$id`s, stable exit codes (0 ok / 1 gate-failed /
 
 ## Status
 
-Pre-v1. Single-developer project; the catalog covers 21 signals across L2–L5. The fix scaffolder covers the L2 catalog; L3+ fix scaffolders are intentionally deferred (the "merge into existing workflow" case needs more design).
+v0.1.0 — first release. Single-developer project; the catalog covers 21 signals across L2–L5. The fix scaffolder covers the L2 catalog; L3+ fix scaffolders are intentionally deferred (the "merge into existing workflow" case needs more design).
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
- **LICENSE** — MIT, copyright 2026 Scott Roberts.
- **README** — links to the LICENSE; status updated to v0.1.0.
- **CLAUDE.md** — corrects the previous note that claimed the arXiv URL and author were illustrative/fictional. The paper is real ([arxiv.org/abs/2604.09388v1](https://arxiv.org/abs/2604.09388v1), Andy Anderson, IBM Research, April 2026). Updated guidance: cite the arXiv URL for claims; quote line ranges from the local \`.md\` when working with specific passages.

## Test plan
- [ ] CI green
- [ ] \`LICENSE\` file present at repo root
- [ ] README footer links to LICENSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)