### PR TITLE
feat: install-skill writes a Claude Code skill for plumbline

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ plumbline inspect l2.agent-instructions
 # Scaffold a missing artifact (dry-run; --apply to actually write).
 plumbline fix l2.agent-instructions
 plumbline fix l2.agent-instructions --apply
+
+# Install a Claude Code skill so AI agents in your repo know how to drive plumbline.
+plumbline install-skill --apply
 ```
 
 ## ACMM levels
@@ -122,7 +125,17 @@ jobs:
 
 `--signal-set v1` pins the rule-set version so the gate can't silently flip when plumbline upgrades. `plumbline help compatibility` documents what each version contains.
 
-## For LLM tool callers
+## Use plumbline from Claude Code (or any agent)
+
+Install the skill into your repo:
+
+```bash
+plumbline install-skill --apply
+```
+
+This writes `.claude/skills/plumbline/SKILL.md` with a hand-tuned guide for AI agents — when to invoke plumbline, the recommended call sequence, the stable signal IDs / schemas / exit codes, and when **not** to invoke it. Once it's in the repo, Claude Code (or any harness that reads `.claude/skills/`) discovers it automatically.
+
+## For LLM tool callers (without the skill)
 
 Recommended call sequence:
 

--- a/cmd/plumbline/install_skill.go
+++ b/cmd/plumbline/install_skill.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sroberts/plumbline/internal/fix"
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// claudeSkillPath is the canonical location for project-local Claude
+// Code skills. Each skill is its own directory under .claude/skills/
+// with a SKILL.md describing when and how to invoke it.
+const claudeSkillPath = ".claude/skills/plumbline/SKILL.md"
+
+func newInstallSkillCmd(stdout, stderr io.Writer) *cobra.Command {
+	var apply bool
+
+	cmd := &cobra.Command{
+		Use:   "install-skill [path]",
+		Short: "Install a Claude Code skill so AI agents in this repo know how to drive plumbline",
+		Long: `plumbline install-skill — write a Claude Code skill into the repo at
+.claude/skills/plumbline/SKILL.md.
+
+Once installed, Claude Code (and any harness that reads .claude/skills/)
+will know when to invoke plumbline and what its stable interfaces are
+(commands, JSON schemas, exit codes, fix-apply safety guards). The
+skill is the canonical "how to use plumbline from an AI agent" guide.
+
+Default is dry-run; --apply is required to actually write. Refuses to
+overwrite an existing SKILL.md so user customizations are preserved
+(remove the existing file manually first if you want to reinstall).
+
+Examples:
+  # See what would be written.
+  plumbline install-skill
+
+  # Install in the current repo.
+  plumbline install-skill --apply
+
+  # Install in a different repo.
+  plumbline install-skill /path/to/repo --apply
+
+Exit codes:
+  0  installed (or dry-run completed)
+  2  could not run (existing skill, path bad, etc.)
+  3  configuration error
+
+See also:
+  plumbline help fix    safety guarantees for plumbline-managed writes
+  plumbline help agents  the same guidance as the skill, but as topical help`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "."
+			if len(args) == 1 {
+				path = args[0]
+			}
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				return errCannotRun(err)
+			}
+
+			plan := acmm.FixPlan{
+				SignalID: "install-skill",
+				Summary:  fmt.Sprintf("Install plumbline Claude Code skill at %s", claudeSkillPath),
+				Ops: []acmm.FixOp{{
+					Kind: acmm.FixCreateFile,
+					Path: claudeSkillPath,
+					Body: []byte(claudeSkillContent),
+				}},
+			}
+
+			res, err := fix.Apply(abs, plan, fix.Options{DryRun: !apply})
+			if err != nil {
+				return errCannotRun(err)
+			}
+
+			emitFixText(stdout, plan, res, abs, !apply)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "Actually write the skill (default is dry-run).")
+	return cmd
+}
+
+// claudeSkillContent is the SKILL.md body. Hand-tuned for AI agents:
+// frontmatter (name + description) so the skill is auto-discoverable;
+// concise body covering when to invoke, recommended call sequence,
+// stable contracts, and when NOT to invoke.
+const claudeSkillContent = `---
+name: plumbline
+description: Use plumbline to assess this repo's AI Codebase Maturity Model (ACMM) level and apply scaffolded fixes. Invoke when the user asks about AI coding readiness, missing instruction files (CLAUDE.md, AGENTS.md, copilot-instructions, .cursorrules, .windsurfrules), CI quality gates, contributor guides, PR templates, commit conventions, or "what should we add next to make this repo better for AI-driven development?"
+---
+
+# plumbline workflow
+
+Plumbline is a deterministic Go CLI that scans a repository for AI coding
+readiness signals and reports its ACMM level (1–5). Detection is
+deterministic — no LLM calls, no network. The CLI is the load-bearing
+interface; an interactive Bubble Tea TUI is also available on terminals.
+
+## When to invoke
+
+- User asks "is this repo ready for AI coding?" or about AI maturity.
+- User asks about adding CLAUDE.md / AGENTS.md / copilot-instructions /
+  .cursorrules / .windsurfrules.
+- User wants to improve PR templates, contributor guides, or commit rules.
+- User asks "what's the next thing to add for better AI workflows?"
+- A plumbline CI gate is failing and you need to know why.
+
+## Recommended call sequence
+
+1. **Get the verdict (machine-readable).**
+
+   ` + "```" + `
+   plumbline --json
+   ` + "```" + `
+
+   Parse ` + "`verdict.level`" + ` (1–5), ` + "`verdict.level_scores`" + ` (per-level
+   averages), and ` + "`verdict.next_gap`" + ` (signals at L+1 not yet Found).
+
+2. **For each signal in next_gap, get evidence + a fix recipe.**
+
+   ` + "```" + `
+   plumbline inspect <signal-id> --json
+   ` + "```" + `
+
+   Returns a ` + "`signal-result`" + ` object with ` + "`status`" + `, ` + "`score`" + `,
+   ` + "`confidence`" + `, ` + "`evidence`" + ` (file paths + excerpts), ` + "`notes`" + `
+   (the "why"), and ` + "`fix_hint`" + ` (the "how to fix").
+
+3. **Preview a scaffolded fix; apply only with explicit confirmation.**
+
+   ` + "```" + `
+   plumbline fix <signal-id>           # dry-run, prints the plan
+   plumbline fix <signal-id> --apply   # actually writes
+   ` + "```" + `
+
+   Inputs (project conventions, anti-patterns, etc.) can be supplied with
+   repeatable ` + "`--input KEY=VALUE`" + ` pairs. Fixers refuse to overwrite
+   existing files; if the target already exists they append a marked
+   block instead.
+
+4. **Discover the catalog.**
+
+   ` + "```" + `
+   plumbline signals --json
+   plumbline schema verdict
+   plumbline schema signal-result
+   ` + "```" + `
+
+## Stable contracts
+
+- **Signal IDs** are stable across patch releases:
+  - L2: ` + "`l2.agent-instructions`" + `, ` + "`l2.contributor-guide`" + `, ` + "`l2.pr-template`" + `, ` + "`l2.commit-rules`" + `
+  - L3: build-lint-gate, coverage-gate, coverage-suite, nightly-compliance, flaky-analysis, error-monitoring, user-feedback, acceptance-tracking
+  - L4: self-modifying-config, auto-triage, threshold-block, worktree-agents, error-recovery
+  - L5: issue-to-pr, self-improvement, docs-from-prs, multi-repo-orchestration
+- **JSON Schemas** (draft 2020-12) for verdict / signal-result / event / config
+  via ` + "`plumbline schema <name>`" + `.
+- **Exit codes**: 0 ok, 1 gate-failed (` + "`--fail-below`" + `), 2 cannot-run, 3 config-error.
+- **Read-only by default.** Only ` + "`plumbline fix --apply`" + ` and
+  ` + "`plumbline install-skill --apply`" + ` write inside the target repo.
+
+## Notes for agents
+
+- Plumbline collapses CLAUDE.md / AGENTS.md / copilot-instructions /
+  .cursorrules / .windsurfrules into ONE signal (` + "`l2.agent-instructions`" + `).
+  Whichever the team uses is fine; don't suggest adding all of them.
+- The four-step partial-credit rubric is fixed: 0.0 / 0.33 / 0.67 / 1.0.
+  Don't propose a "0.5" — it's not in the rubric.
+- ` + "`--min-confidence high`" + ` is the right CI-gate strictness if the
+  verdict can't tolerate low-confidence (filename-only) matches.
+- Workflow signals (L3+) parse GitHub Actions YAML only in MVP; other
+  CI systems are deferred behind ` + "`--ci-system`" + `.
+
+## When NOT to invoke
+
+- General code review (use the user's preferred review tool).
+- Test coverage analysis itself (plumbline detects whether a coverage
+  *gate* exists; it doesn't compute coverage).
+- Static analysis on application code (use golangci-lint, eslint, etc.).
+- Anything that requires running the user's tests / building their app.
+
+## Reference
+
+- Spec: ` + "`SPEC.md`" + ` in this repo (or in the plumbline repo if you've
+  installed it via ` + "`go install`" + `).
+- Source paper: https://arxiv.org/abs/2604.09388v1 (Andy Anderson,
+  "The AI Codebase Maturity Model", IBM Research).
+- Topical help: ` + "`plumbline help <topic>`" + ` (levels, signals, scoring,
+  output, config, ci, agents, profiles, compatibility, fix).
+`

--- a/cmd/plumbline/install_skill_test.go
+++ b/cmd/plumbline/install_skill_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallSkill_DryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	code, out, _ := runCLI(t, "install-skill", dir)
+	if code != exitOK {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out, "DRY-RUN") {
+		t.Errorf("dry-run output should say so; got:\n%s", out)
+	}
+	target := filepath.Join(dir, ".claude", "skills", "plumbline", "SKILL.md")
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("dry-run must not create the skill file at %s", target)
+	}
+}
+
+func TestInstallSkill_ApplyWritesSkill(t *testing.T) {
+	dir := t.TempDir()
+	code, _, errOut := runCLI(t, "install-skill", dir, "--apply")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, errOut)
+	}
+	target := filepath.Join(dir, ".claude", "skills", "plumbline", "SKILL.md")
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("expected skill at %s, got: %v", target, err)
+	}
+	body := string(got)
+	for _, want := range []string{
+		"name: plumbline",
+		"description:",
+		"plumbline --json",
+		"plumbline fix",
+		"plumbline inspect",
+		"l2.agent-instructions",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("skill body missing %q", want)
+		}
+	}
+}
+
+func TestInstallSkill_RefusesToOverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".claude", "skills", "plumbline", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("user-customized skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, errOut := runCLI(t, "install-skill", dir, "--apply")
+	if code == exitOK {
+		t.Errorf("expected non-zero exit when skill already exists")
+	}
+	if !strings.Contains(errOut, "already exists") {
+		t.Errorf("error message should mention 'already exists'; got: %s", errOut)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "user-customized skill" {
+		t.Errorf("existing skill was overwritten; content=%q", got)
+	}
+}
+
+func TestInstallSkill_RootCommandIsRegistered(t *testing.T) {
+	code, out, _ := runCLI(t, "install-skill", "--help")
+	if code != exitOK {
+		t.Fatalf("exit = %d, want 0 (--help should always succeed)", code)
+	}
+	if !strings.Contains(out, "Claude Code skill") {
+		t.Errorf("--help output should mention Claude Code skill; got:\n%s", out)
+	}
+}

--- a/cmd/plumbline/main.go
+++ b/cmd/plumbline/main.go
@@ -110,6 +110,7 @@ publish schemas, etc.). Run 'plumbline help' for topical guides.`,
 		newExplainCmd(stdout, stderr),
 		newSchemaCmd(stdout, stderr),
 		newFixCmd(stdout, stderr),
+		newInstallSkillCmd(stdout, stderr),
 		newVersionCmd(stdout),
 	)
 


### PR DESCRIPTION
New top-level command: \`plumbline install-skill [path] [--apply]\`. Writes \`.claude/skills/plumbline/SKILL.md\` so Claude Code (and any harness that reads \`.claude/skills/\`) auto-discovers when and how to invoke plumbline.

## Why this matters

The CLI and JSON schemas already work for LLM tool callers, but they're external. A skill is the **discoverable** form: drop it in a repo and Claude Code will know plumbline exists and how to drive it the next time the user asks "is this repo ready for AI coding?" or "what's the next thing I should add?"

## What the skill body covers

Hand-tuned for AI agents, not human readers:
- Frontmatter (\`name\` + \`description\`) describing exactly when to invoke.
- Recommended call sequence (\`assess --json\` → \`inspect --json\` on each \`next_gap\` entry → \`fix --apply\` with confirmation).
- Stable contracts: signal IDs, JSON Schema names, exit codes.
- Notes that matter for agents (the four-step rubric, \`--min-confidence\` semantics, GitHub-Actions-only workflow signals in MVP, the agent-instructions deviation from the source paper).
- A \"When NOT to invoke\" section so the agent doesn't reach for plumbline on general code review / coverage analysis / static analysis tasks.

## Safety

Reuses \`internal/fix.Apply\` so the install inherits all the existing guards:
- Dry-run by default; \`--apply\` required to write.
- Refuses to overwrite an existing \`SKILL.md\` (preserves user customizations).
- Paths resolve inside repo root.

## Quick start

\`\`\`
# See what would be written.
plumbline install-skill

# Install in the current repo.
plumbline install-skill --apply

# Install in a different repo.
plumbline install-skill /path/to/repo --apply
\`\`\`

## Tests
- \`TestInstallSkill_DryRunDoesNotWrite\` — no file created in dry-run
- \`TestInstallSkill_ApplyWritesSkill\` — file created with expected content (frontmatter, key commands, stable signal IDs)
- \`TestInstallSkill_RefusesToOverwriteExisting\` — existing skill is preserved
- \`TestInstallSkill_RootCommandIsRegistered\` — \`--help\` works and mentions Claude Code

## Test plan
- [ ] \`make test\`
- [ ] \`./plumbline install-skill /tmp/scratch --apply\` produces \`.claude/skills/plumbline/SKILL.md\`
- [ ] Re-running \`--apply\` errors with \"already exists\"
- [ ] Open the generated skill in Claude Code; ask \"how AI-ready is this repo?\" and verify the agent invokes plumbline

🤖 Generated with [Claude Code](https://claude.com/claude-code)