### PR TITLE
tui: install-skill flow gated on whether the skill is already present

### DIFF
--- a/cmd/plumbline/install_skill.go
+++ b/cmd/plumbline/install_skill.go
@@ -1,20 +1,14 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sroberts/plumbline/internal/fix"
-	"github.com/sroberts/plumbline/pkg/acmm"
+	"github.com/sroberts/plumbline/internal/skill"
 )
-
-// claudeSkillPath is the canonical location for project-local Claude
-// Code skills. Each skill is its own directory under .claude/skills/
-// with a SKILL.md describing when and how to invoke it.
-const claudeSkillPath = ".claude/skills/plumbline/SKILL.md"
 
 func newInstallSkillCmd(stdout, stderr io.Writer) *cobra.Command {
 	var apply bool
@@ -34,6 +28,10 @@ Default is dry-run; --apply is required to actually write. Refuses to
 overwrite an existing SKILL.md so user customizations are preserved
 (remove the existing file manually first if you want to reinstall).
 
+The TUI surfaces the same install action: bare 'plumbline' on a
+terminal shows an [i] install skill hint when the skill isn't already
+present in the scanned repo.
+
 Examples:
   # See what would be written.
   plumbline install-skill
@@ -50,8 +48,8 @@ Exit codes:
   3  configuration error
 
 See also:
-  plumbline help fix    safety guarantees for plumbline-managed writes
-  plumbline help agents  the same guidance as the skill, but as topical help`,
+  plumbline help fix      safety guarantees for plumbline-managed writes
+  plumbline help agents   the same guidance as the skill, but as topical help`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := "."
@@ -63,16 +61,7 @@ See also:
 				return errCannotRun(err)
 			}
 
-			plan := acmm.FixPlan{
-				SignalID: "install-skill",
-				Summary:  fmt.Sprintf("Install plumbline Claude Code skill at %s", claudeSkillPath),
-				Ops: []acmm.FixOp{{
-					Kind: acmm.FixCreateFile,
-					Path: claudeSkillPath,
-					Body: []byte(claudeSkillContent),
-				}},
-			}
-
+			plan := skill.NewPlan()
 			res, err := fix.Apply(abs, plan, fix.Options{DryRun: !apply})
 			if err != nil {
 				return errCannotRun(err)
@@ -85,112 +74,3 @@ See also:
 	cmd.Flags().BoolVar(&apply, "apply", false, "Actually write the skill (default is dry-run).")
 	return cmd
 }
-
-// claudeSkillContent is the SKILL.md body. Hand-tuned for AI agents:
-// frontmatter (name + description) so the skill is auto-discoverable;
-// concise body covering when to invoke, recommended call sequence,
-// stable contracts, and when NOT to invoke.
-const claudeSkillContent = `---
-name: plumbline
-description: Use plumbline to assess this repo's AI Codebase Maturity Model (ACMM) level and apply scaffolded fixes. Invoke when the user asks about AI coding readiness, missing instruction files (CLAUDE.md, AGENTS.md, copilot-instructions, .cursorrules, .windsurfrules), CI quality gates, contributor guides, PR templates, commit conventions, or "what should we add next to make this repo better for AI-driven development?"
----
-
-# plumbline workflow
-
-Plumbline is a deterministic Go CLI that scans a repository for AI coding
-readiness signals and reports its ACMM level (1–5). Detection is
-deterministic — no LLM calls, no network. The CLI is the load-bearing
-interface; an interactive Bubble Tea TUI is also available on terminals.
-
-## When to invoke
-
-- User asks "is this repo ready for AI coding?" or about AI maturity.
-- User asks about adding CLAUDE.md / AGENTS.md / copilot-instructions /
-  .cursorrules / .windsurfrules.
-- User wants to improve PR templates, contributor guides, or commit rules.
-- User asks "what's the next thing to add for better AI workflows?"
-- A plumbline CI gate is failing and you need to know why.
-
-## Recommended call sequence
-
-1. **Get the verdict (machine-readable).**
-
-   ` + "```" + `
-   plumbline --json
-   ` + "```" + `
-
-   Parse ` + "`verdict.level`" + ` (1–5), ` + "`verdict.level_scores`" + ` (per-level
-   averages), and ` + "`verdict.next_gap`" + ` (signals at L+1 not yet Found).
-
-2. **For each signal in next_gap, get evidence + a fix recipe.**
-
-   ` + "```" + `
-   plumbline inspect <signal-id> --json
-   ` + "```" + `
-
-   Returns a ` + "`signal-result`" + ` object with ` + "`status`" + `, ` + "`score`" + `,
-   ` + "`confidence`" + `, ` + "`evidence`" + ` (file paths + excerpts), ` + "`notes`" + `
-   (the "why"), and ` + "`fix_hint`" + ` (the "how to fix").
-
-3. **Preview a scaffolded fix; apply only with explicit confirmation.**
-
-   ` + "```" + `
-   plumbline fix <signal-id>           # dry-run, prints the plan
-   plumbline fix <signal-id> --apply   # actually writes
-   ` + "```" + `
-
-   Inputs (project conventions, anti-patterns, etc.) can be supplied with
-   repeatable ` + "`--input KEY=VALUE`" + ` pairs. Fixers refuse to overwrite
-   existing files; if the target already exists they append a marked
-   block instead.
-
-4. **Discover the catalog.**
-
-   ` + "```" + `
-   plumbline signals --json
-   plumbline schema verdict
-   plumbline schema signal-result
-   ` + "```" + `
-
-## Stable contracts
-
-- **Signal IDs** are stable across patch releases:
-  - L2: ` + "`l2.agent-instructions`" + `, ` + "`l2.contributor-guide`" + `, ` + "`l2.pr-template`" + `, ` + "`l2.commit-rules`" + `
-  - L3: build-lint-gate, coverage-gate, coverage-suite, nightly-compliance, flaky-analysis, error-monitoring, user-feedback, acceptance-tracking
-  - L4: self-modifying-config, auto-triage, threshold-block, worktree-agents, error-recovery
-  - L5: issue-to-pr, self-improvement, docs-from-prs, multi-repo-orchestration
-- **JSON Schemas** (draft 2020-12) for verdict / signal-result / event / config
-  via ` + "`plumbline schema <name>`" + `.
-- **Exit codes**: 0 ok, 1 gate-failed (` + "`--fail-below`" + `), 2 cannot-run, 3 config-error.
-- **Read-only by default.** Only ` + "`plumbline fix --apply`" + ` and
-  ` + "`plumbline install-skill --apply`" + ` write inside the target repo.
-
-## Notes for agents
-
-- Plumbline collapses CLAUDE.md / AGENTS.md / copilot-instructions /
-  .cursorrules / .windsurfrules into ONE signal (` + "`l2.agent-instructions`" + `).
-  Whichever the team uses is fine; don't suggest adding all of them.
-- The four-step partial-credit rubric is fixed: 0.0 / 0.33 / 0.67 / 1.0.
-  Don't propose a "0.5" — it's not in the rubric.
-- ` + "`--min-confidence high`" + ` is the right CI-gate strictness if the
-  verdict can't tolerate low-confidence (filename-only) matches.
-- Workflow signals (L3+) parse GitHub Actions YAML only in MVP; other
-  CI systems are deferred behind ` + "`--ci-system`" + `.
-
-## When NOT to invoke
-
-- General code review (use the user's preferred review tool).
-- Test coverage analysis itself (plumbline detects whether a coverage
-  *gate* exists; it doesn't compute coverage).
-- Static analysis on application code (use golangci-lint, eslint, etc.).
-- Anything that requires running the user's tests / building their app.
-
-## Reference
-
-- Spec: ` + "`SPEC.md`" + ` in this repo (or in the plumbline repo if you've
-  installed it via ` + "`go install`" + `).
-- Source paper: https://arxiv.org/abs/2604.09388v1 (Andy Anderson,
-  "The AI Codebase Maturity Model", IBM Research).
-- Topical help: ` + "`plumbline help <topic>`" + ` (levels, signals, scoring,
-  output, config, ci, agents, profiles, compatibility, fix).
-`

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,0 +1,136 @@
+// Package skill holds the embedded Claude Code skill that
+// `plumbline install-skill` writes into a target repo. Path and Body
+// are exported so both the install-skill command and the TUI can
+// reference them without depending on the cmd/plumbline package.
+package skill
+
+import "github.com/sroberts/plumbline/pkg/acmm"
+
+// Path is the canonical location for project-local Claude Code skills.
+// Each skill lives in its own directory under .claude/skills/.
+const Path = ".claude/skills/plumbline/SKILL.md"
+
+// Body is the SKILL.md content. Hand-tuned for AI agents: frontmatter
+// (name + description) so the skill is auto-discoverable; concise body
+// covering when to invoke, recommended call sequence, stable contracts,
+// and when NOT to invoke.
+const Body = `---
+name: plumbline
+description: Use plumbline to assess this repo's AI Codebase Maturity Model (ACMM) level and apply scaffolded fixes. Invoke when the user asks about AI coding readiness, missing instruction files (CLAUDE.md, AGENTS.md, copilot-instructions, .cursorrules, .windsurfrules), CI quality gates, contributor guides, PR templates, commit conventions, or "what should we add next to make this repo better for AI-driven development?"
+---
+
+# plumbline workflow
+
+Plumbline is a deterministic Go CLI that scans a repository for AI coding
+readiness signals and reports its ACMM level (1–5). Detection is
+deterministic — no LLM calls, no network. The CLI is the load-bearing
+interface; an interactive Bubble Tea TUI is also available on terminals.
+
+## When to invoke
+
+- User asks "is this repo ready for AI coding?" or about AI maturity.
+- User asks about adding CLAUDE.md / AGENTS.md / copilot-instructions /
+  .cursorrules / .windsurfrules.
+- User wants to improve PR templates, contributor guides, or commit rules.
+- User asks "what's the next thing to add for better AI workflows?"
+- A plumbline CI gate is failing and you need to know why.
+
+## Recommended call sequence
+
+1. **Get the verdict (machine-readable).**
+
+   ` + "```" + `
+   plumbline --json
+   ` + "```" + `
+
+   Parse ` + "`verdict.level`" + ` (1–5), ` + "`verdict.level_scores`" + ` (per-level
+   averages), and ` + "`verdict.next_gap`" + ` (signals at L+1 not yet Found).
+
+2. **For each signal in next_gap, get evidence + a fix recipe.**
+
+   ` + "```" + `
+   plumbline inspect <signal-id> --json
+   ` + "```" + `
+
+   Returns a ` + "`signal-result`" + ` object with ` + "`status`" + `, ` + "`score`" + `,
+   ` + "`confidence`" + `, ` + "`evidence`" + ` (file paths + excerpts), ` + "`notes`" + `
+   (the "why"), and ` + "`fix_hint`" + ` (the "how to fix").
+
+3. **Preview a scaffolded fix; apply only with explicit confirmation.**
+
+   ` + "```" + `
+   plumbline fix <signal-id>           # dry-run, prints the plan
+   plumbline fix <signal-id> --apply   # actually writes
+   ` + "```" + `
+
+   Inputs (project conventions, anti-patterns, etc.) can be supplied with
+   repeatable ` + "`--input KEY=VALUE`" + ` pairs. Fixers refuse to overwrite
+   existing files; if the target already exists they append a marked
+   block instead.
+
+4. **Discover the catalog.**
+
+   ` + "```" + `
+   plumbline signals --json
+   plumbline schema verdict
+   plumbline schema signal-result
+   ` + "```" + `
+
+## Stable contracts
+
+- **Signal IDs** are stable across patch releases:
+  - L2: ` + "`l2.agent-instructions`" + `, ` + "`l2.contributor-guide`" + `, ` + "`l2.pr-template`" + `, ` + "`l2.commit-rules`" + `
+  - L3: build-lint-gate, coverage-gate, coverage-suite, nightly-compliance, flaky-analysis, error-monitoring, user-feedback, acceptance-tracking
+  - L4: self-modifying-config, auto-triage, threshold-block, worktree-agents, error-recovery
+  - L5: issue-to-pr, self-improvement, docs-from-prs, multi-repo-orchestration
+- **JSON Schemas** (draft 2020-12) for verdict / signal-result / event / config
+  via ` + "`plumbline schema <name>`" + `.
+- **Exit codes**: 0 ok, 1 gate-failed (` + "`--fail-below`" + `), 2 cannot-run, 3 config-error.
+- **Read-only by default.** Only ` + "`plumbline fix --apply`" + ` and
+  ` + "`plumbline install-skill --apply`" + ` write inside the target repo.
+
+## Notes for agents
+
+- Plumbline collapses CLAUDE.md / AGENTS.md / copilot-instructions /
+  .cursorrules / .windsurfrules into ONE signal (` + "`l2.agent-instructions`" + `).
+  Whichever the team uses is fine; don't suggest adding all of them.
+- The four-step partial-credit rubric is fixed: 0.0 / 0.33 / 0.67 / 1.0.
+  Don't propose a "0.5" — it's not in the rubric.
+- ` + "`--min-confidence high`" + ` is the right CI-gate strictness if the
+  verdict can't tolerate low-confidence (filename-only) matches.
+- Workflow signals (L3+) parse GitHub Actions YAML only in MVP; other
+  CI systems are deferred behind ` + "`--ci-system`" + `.
+
+## When NOT to invoke
+
+- General code review (use the user's preferred review tool).
+- Test coverage analysis itself (plumbline detects whether a coverage
+  *gate* exists; it doesn't compute coverage).
+- Static analysis on application code (use golangci-lint, eslint, etc.).
+- Anything that requires running the user's tests / building their app.
+
+## Reference
+
+- Spec: ` + "`SPEC.md`" + ` in this repo (or in the plumbline repo if you've
+  installed it via ` + "`go install`" + `).
+- Source paper: https://arxiv.org/abs/2604.09388v1 (Andy Anderson,
+  "The AI Codebase Maturity Model", IBM Research).
+- Topical help: ` + "`plumbline help <topic>`" + ` (levels, signals, scoring,
+  output, config, ci, agents, profiles, compatibility, fix).
+`
+
+// NewPlan returns the canonical install-skill FixPlan that both the
+// install-skill command and the TUI consume. Wrapping the constants
+// in a function keeps the call sites uniform if per-repo customization
+// is ever added.
+func NewPlan() acmm.FixPlan {
+	return acmm.FixPlan{
+		SignalID: "install-skill",
+		Summary:  "Install plumbline Claude Code skill at " + Path,
+		Ops: []acmm.FixOp{{
+			Kind: acmm.FixCreateFile,
+			Path: Path,
+			Body: []byte(Body),
+		}},
+	}
+}

--- a/internal/tui/install_skill_test.go
+++ b/internal/tui/install_skill_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/sroberts/plumbline/internal/scanner"
+	"github.com/sroberts/plumbline/internal/skill"
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// idxWithFiles builds a RepoIndex from a synthetic file map.
+func idxWithFiles(t *testing.T, files fstest.MapFS) *scanner.RepoIndex {
+	t.Helper()
+	idx, err := scanner.ScanFS(files, "/test")
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	return idx
+}
+
+func TestTUI_SkillInstalledReflectsScanResult(t *testing.T) {
+	withSkill := idxWithFiles(t, fstest.MapFS{
+		skill.Path: {Data: []byte("# existing skill")},
+	})
+	withoutSkill := idxWithFiles(t, fstest.MapFS{
+		"README.md": {Data: []byte("# r")},
+	})
+
+	if !skillIsInstalled(withSkill) {
+		t.Error("skillIsInstalled = false when SKILL.md is in the index")
+	}
+	if skillIsInstalled(withoutSkill) {
+		t.Error("skillIsInstalled = true when SKILL.md is NOT in the index")
+	}
+}
+
+func TestTUI_IKeyTriggersInstallFlowWhenAbsent(t *testing.T) {
+	scan, _ := runScanCount(acmm.Report{
+		Repo:    "/test",
+		Verdict: acmm.Verdict{Level: acmm.LevelInstructed, Name: "Instructed"},
+		Signals: []acmm.SignalResult{{ID: "l2.x", Status: acmm.StatusFound}},
+	})
+	m := New(scan).(*model)
+	completeScan(t, m, m.report)
+	m.idx = idxWithFiles(t, fstest.MapFS{"README.md": {Data: []byte("# r")}})
+
+	out, _ := m.Update(keyMsg("i"))
+	*m = *(out.(*model))
+
+	if m.screen != screenFixPreview {
+		t.Errorf("after 'i' on results, screen = %v, want screenFixPreview", m.screen)
+	}
+	if m.fixPlan.SignalID != "install-skill" {
+		t.Errorf("fixPlan.SignalID = %q, want install-skill", m.fixPlan.SignalID)
+	}
+	if len(m.fixPlan.Ops) != 1 || m.fixPlan.Ops[0].Path != skill.Path {
+		t.Errorf("fixPlan op should target %s; got %+v", skill.Path, m.fixPlan.Ops)
+	}
+}
+
+func TestTUI_IKeyIsNoOpWhenSkillAlreadyInstalled(t *testing.T) {
+	scan, _ := runScanCount(acmm.Report{
+		Repo:    "/test",
+		Verdict: acmm.Verdict{Level: acmm.LevelInstructed},
+		Signals: []acmm.SignalResult{{ID: "l2.x", Status: acmm.StatusFound}},
+	})
+	m := New(scan).(*model)
+	completeScan(t, m, m.report)
+	m.idx = idxWithFiles(t, fstest.MapFS{
+		skill.Path: {Data: []byte("# already there")},
+	})
+
+	out, _ := m.Update(keyMsg("i"))
+	*m = *(out.(*model))
+
+	if m.screen != screenResults {
+		t.Errorf("'i' should be a no-op when skill is installed; screen = %v", m.screen)
+	}
+}
+
+func TestTUI_ResultsHintShowsInstallSkillOnlyWhenAbsent(t *testing.T) {
+	scan, _ := runScanCount(acmm.Report{
+		Repo:    "/test",
+		Verdict: acmm.Verdict{Level: acmm.LevelInstructed},
+		Signals: []acmm.SignalResult{{ID: "l2.x", Status: acmm.StatusFound}},
+	})
+
+	// Skill absent → hint mentions [i] install.
+	m := New(scan).(*model)
+	completeScan(t, m, m.report)
+	m.idx = idxWithFiles(t, fstest.MapFS{"README.md": {Data: []byte("# r")}})
+	view := m.View()
+	if !strings.Contains(view, "[i] install skill") {
+		t.Errorf("results view should advertise [i] install skill when absent; got:\n%s", view)
+	}
+
+	// Skill present → hint omits the [i] line.
+	m2 := New(scan).(*model)
+	completeScan(t, m2, m2.report)
+	m2.idx = idxWithFiles(t, fstest.MapFS{
+		skill.Path: {Data: []byte("# present")},
+	})
+	view2 := m2.View()
+	if strings.Contains(view2, "[i] install skill") {
+		t.Errorf("results view should NOT advertise [i] install skill when present; got:\n%s", view2)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -15,9 +15,22 @@ import (
 	"github.com/sroberts/plumbline/internal/fix"
 	"github.com/sroberts/plumbline/internal/scanner"
 	"github.com/sroberts/plumbline/internal/signals"
+	"github.com/sroberts/plumbline/internal/skill"
 	"github.com/sroberts/plumbline/internal/textwrap"
 	"github.com/sroberts/plumbline/pkg/acmm"
 )
+
+// skillIsInstalled reports whether the plumbline Claude Code skill
+// already exists in the scanned repo. The TUI gates the [i] install
+// hint on this — there's no value showing an install option for a
+// skill that's already there.
+func skillIsInstalled(idx *scanner.RepoIndex) bool {
+	if idx == nil {
+		return false
+	}
+	_, err := idx.Read(skill.Path)
+	return err == nil
+}
 
 // ScanFunc is the work the TUI delegates to the assess pipeline. It
 // returns both the human-readable Report (rendered on screen) and the
@@ -153,7 +166,22 @@ func (m *model) updateResults(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "r":
 		return m.rescan()
+	case "i":
+		return m.startInstallSkill()
 	}
+	return m, nil
+}
+
+// startInstallSkill builds the install-skill FixPlan and jumps to the
+// preview screen. No-op if the skill is already installed (the hint
+// is hidden in that case, but defensive against rebound key events).
+func (m *model) startInstallSkill() (tea.Model, tea.Cmd) {
+	if skillIsInstalled(m.idx) {
+		return m, nil
+	}
+	m.fixer = nil // skill install is not tied to a Signal
+	m.fixPlan = skill.NewPlan()
+	m.screen = screenFixPreview
 	return m, nil
 }
 
@@ -413,7 +441,12 @@ func (m *model) renderResults() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(styleHint.Render("[↑/↓] select   [enter] detail   [r] rescan   [✚=fixable]   [q] quit"))
+	hint := "[↑/↓] select   [enter] detail   [r] rescan   [✚=fixable]"
+	if !skillIsInstalled(m.idx) {
+		hint += "   [i] install skill"
+	}
+	hint += "   [q] quit"
+	b.WriteString(styleHint.Render(hint))
 	return b.String()
 }
 
@@ -557,7 +590,13 @@ func (m *model) renderFixPreview() string {
 
 func (m *model) renderFixDone() string {
 	var b strings.Builder
-	b.WriteString(styleHeader.Render(fmt.Sprintf("Fix · %s", m.fixer.ID())))
+	// fixer is nil for the install-skill flow (no Signal involved); use
+	// the FixPlan's SignalID as the heading instead.
+	id := m.fixPlan.SignalID
+	if m.fixer != nil {
+		id = m.fixer.ID()
+	}
+	b.WriteString(styleHeader.Render(fmt.Sprintf("Fix · %s", id)))
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", min(60, m.viewWidth())))
 	b.WriteString("\n\n")


### PR DESCRIPTION
**Stacked on PR #13.** Re-target to \`main\` after #13 merges.

Adds an \`[i] install skill\` action to the TUI results screen. The hint is shown only when the scanned RepoIndex doesn't already contain \`.claude/skills/plumbline/SKILL.md\` — no point advertising an install for a skill that's already there.

## UX

Pressing **i** on the results screen:
- **No-op** if the skill is already installed (defensive — the hint is hidden in that case, but a stray rebound shouldn't do anything either).
- Otherwise builds the canonical install-skill \`FixPlan\` inline and jumps to the existing **screenFixPreview**. User gets the same preview / **y**/**n** confirm / done flow as for fix application; reuses all the same safety guards.

Footer hint on results screen now reads:
\`\`\`
[↑/↓] select   [enter] detail   [r] rescan   [✚=fixable]   [i] install skill   [q] quit
\`\`\`
…with the \`[i] install skill\` segment dropped when the skill is already present.

## Refactor

- New \`internal/skill\` package with \`Path\`, \`Body\`, and \`NewPlan()\` exported. Both the \`install-skill\` CLI command and the TUI import it.
- \`cmd/plumbline/install_skill.go\` shrinks from ~200 lines to ~80 (the ~100-line skill body moved to the package).
- \`renderFixDone\` falls back to \`fixPlan.SignalID\` when there's no \`fixer\` (skill installs aren't tied to a Signal).

## Tests

Four new tests in \`internal/tui/install_skill_test.go\`:
1. \`skillIsInstalled\` correctly detects presence/absence
2. \`i\` key triggers the install flow when skill is absent
3. \`i\` key is a no-op when skill is already installed
4. Hint line includes/omits \`[i] install skill\` based on presence

## Test plan
- [ ] \`make test\`
- [ ] \`./plumbline\` (TUI) on a repo without the skill → footer shows \`[i] install skill\`; press \`i\` → preview screen → \`y\` → done
- [ ] After applying, press \`r\` to rescan → footer no longer shows \`[i] install skill\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)