### PR TITLE
chore: gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ coverage.html
 *.swp
 .idea/
 .vscode/
+
+# Claude Code project-local state. The plumbline-installed skill at
+# .claude/skills/plumbline/SKILL.md is intentionally per-developer:
+# anyone who wants it runs `plumbline install-skill --apply` in their
+# own checkout. Don't ship it as part of the source tree — it would
+# get stale relative to the in-binary copy in internal/skill/skill.go.
+.claude/


### PR DESCRIPTION
The plumbline-installed Claude Code skill at \`.claude/skills/plumbline/SKILL.md\` is per-developer state, not source-tree content. Anyone who wants it in a fresh checkout runs \`plumbline install-skill --apply\` themselves; the canonical body lives in \`internal/skill/skill.go\` and is embedded in the binary, so a committed copy would just drift relative to that.

## History
\`.claude/\` has **never been committed** to this repo (\`git log --all --full-history -- .claude\` returns empty), so no history rewrite is needed — this is purely a forward-looking ignore rule to keep it out of future commits.

## Test plan
- [ ] After merge, run \`plumbline install-skill --apply\` in a fresh checkout — the file gets written but \`git status\` doesn't show it
- [ ] \`git ls-files | grep .claude\` is empty before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)