### PR TITLE
chore: raise plumbline to ACMM level 2 (dogfooded via 'plumbline fix')

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- One paragraph: what changed and why. -->
+
+## Test plan
+
+- [ ] Unit tests cover the change
+- [ ] Lint and type-check pass
+- [ ] Manual smoke check (if UI / behavior changed)
+- [ ] Docs updated (if a public surface changed)
+- [ ] No unrelated formatting churn in the diff
+
+## Risks / rollback
+
+<!-- What could go wrong; how to revert if it does. -->

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,11 @@
+# subject (≤72 chars): <type>(<scope>): <imperative summary>
+#
+# Body — wrap at 72 characters. Explain WHY this change is needed and
+# WHAT the user-visible effect is. Skip the "what" if the diff is
+# self-explanatory.
+#
+# <type>: feat | fix | docs | refactor | test | chore | perf | ci
+#
+# After saving, run:
+#   git config commit.template .gitmessage
+# (the per-repo .git/config is local, so each contributor opts in).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+Welcome. This guide is the canonical source for how PRs get reviewed
+and merged in this repository — both for human contributors and for
+AI coding agents.
+
+## Workflow
+
+1. Branch from main: `git checkout -b <type>/<short-name>`.
+2. Make focused commits — one logical change per PR.
+3. Run the full test suite locally before opening the PR.
+4. Open a PR; the template lists the per-merge checks.
+
+## What gets a PR rejected
+
+- Tests don't cover the change (table-driven for branchy code; teatest
+  for TUI flows; subprocess E2E for CLI binary behavior).
+- Signal IDs renamed without a deprecation alias — they're part of the
+  public contract per [SPEC.md §7](SPEC.md).
+- New behavior added without updating SPEC.md or `plumbline help` topics.
+- The skill body in `internal/skill/skill.go` diverged from what
+  `plumbline install-skill` actually writes.
+- LLM calls or network IO in the default path. Plumbline is
+  deterministic by design — see SPEC.md §3.
+- Signal scoring not on the four-step rubric (`0.0 / 0.33 / 0.67 / 1.0`).
+- Direct `os.ReadFile` (or any direct IO) inside a Signal's `Detect`.
+  Use `idx.Read(path)` — that's the access-contract chokepoint per
+  SPEC.md §5.
+- `gofmt`, `go vet`, or `go test -race ./...` not green locally before
+  opening the PR.
+
+## Local checks
+
+Before opening a PR, run:
+
+```bash
+make build     # cross-check the ldflags
+make test      # full unit + E2E suite
+make test-race # race detector
+make lint      # gofmt + go vet (golangci-lint if installed)
+```
+
+CI (`.github/workflows/ci.yml`) runs the same gate on every PR.
+
+## Where things live
+
+- **Public API:** `pkg/acmm` — types consumed by `--json` output.
+- **Scanner / index:** `internal/scanner` — the IO chokepoint.
+- **Signals:** `internal/signals/lN/<id>.go` — one file per detector.
+  Adding a signal is a single-file change; register via `init()`.
+- **Fix application:** `internal/fix` — the only place plumbline
+  writes inside a target repo. Refuses overwrite, in-repo only.
+- **Workflows AST:** `internal/workflows` — GitHub Actions YAML parser.
+- **Embedded skill bodies:** `internal/skill` — what
+  `plumbline install-skill` writes for each agent target.
+- **TUI:** `internal/tui` — Bubble Tea screens + picker flows.
+
+## Style
+
+- Format with `gofmt`. Don't reformat unrelated lines; keep diffs minimal.
+- Comments explain WHY, not WHAT — well-named identifiers carry the
+  WHAT.
+- Errors propagate up; don't swallow them silently.
+
+## Asking for help
+
+Open a draft PR or an issue. Don't sit on a stuck branch — small
+feedback loops beat one heroic perfect PR.


### PR DESCRIPTION
Used plumbline against itself to generate the missing L2 artifacts. Every file in this PR was scaffolded by \`plumbline fix --apply\`.

## Before

\`\`\`
Verdict: L1 (Assisted)
  L2:  25%
  L3:  21%
  L4:   0%
  L5:   0%

Next-level gap (to reach L2):
  l2.commit-rules
  l2.contributor-guide
  l2.pr-template
\`\`\`

## After

\`\`\`
Verdict: L2 (Instructed)
  L2: 100%   ← passes 0.7 threshold
  L3:  21%
  L4:   0%
  L5:   0%

L2 signals:
  l2.agent-instructions     found  (CLAUDE.md, was already present)
  l2.commit-rules           found  (.gitmessage)
  l2.contributor-guide      found  (CONTRIBUTING.md)
  l2.pr-template            found  (.github/pull_request_template.md)
\`\`\`

## Files added

| File | How |
|---|---|
| \`.gitmessage\` | \`plumbline fix l2.commit-rules --apply\` |
| \`.github/pull_request_template.md\` | \`plumbline fix l2.pr-template --apply\` |
| \`CONTRIBUTING.md\` | \`plumbline fix l2.contributor-guide --apply\` (then expanded by hand to clear the 20-line bar with substantive content — see notes) |

## Notes on CONTRIBUTING.md

The scaffolded body landed at 17 non-blank lines, just below the L2 substantive bar (≥20). Rather than re-scaffolding I expanded it by hand with sections that are genuinely useful here:

- **Explicit PR-rejection criteria.** Stable signal IDs are a public contract; SPEC.md drift is a reject; the deterministic-by-default invariant; the direct-IO ban inside Signal.Detect; gofmt/race gate. These mirror invariants from SPEC.md.
- **Local-checks reference.** \`make build / test / test-race / lint\` — the same gate CI runs.
- **Where things live.** A quick package map (\`pkg/acmm\`, \`internal/scanner\`, \`internal/signals/lN/\`, \`internal/fix\`, \`internal/workflows\`, \`internal/skill\`, \`internal/tui\`) so anyone landing fresh in the repo knows where to look.

## Verification
- [ ] \`./plumbline\` after merge reports L2 / 100%
- [ ] \`./plumbline signals --level 2 --json\` — all four entries Found
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)