### PR TITLE
fix(l3): user-feedback no longer self-detects on plumbline source

### DIFF
--- a/internal/signals/l3/l3_test.go
+++ b/internal/signals/l3/l3_test.go
@@ -194,3 +194,36 @@ func TestAcceptanceTracking(t *testing.T) {
 		t.Errorf("auto-qa-tuning.json: score = %v, want Found", got.Score)
 	}
 }
+
+func TestUserFeedback_DoesNotSelfDetectOnPlumblineSource(t *testing.T) {
+	// Plumbline's own internal/signals/l3/user_feedback.go used to be a
+	// false positive. Detection must require a frontend-shaped path
+	// in addition to a feedback-flavored filename.
+	files := fstest.MapFS{
+		"internal/signals/l3/user_feedback.go": {Data: []byte("package l3")},
+	}
+	got := runOn(t, UserFeedback{}, files)
+	if got.Score != acmm.ScoreMissing {
+		t.Errorf("self-detection: score = %v, want missing", got.Score)
+	}
+}
+
+func TestUserFeedback_MatchesGenuineComponent(t *testing.T) {
+	files := fstest.MapFS{
+		"web/src/hooks/useNPSSurvey.ts": {Data: []byte("export const useNPSSurvey = () => {}")},
+	}
+	got := runOn(t, UserFeedback{}, files)
+	if got.Score != acmm.ScoreFound {
+		t.Errorf("genuine NPS component: score = %v, want found", got.Score)
+	}
+}
+
+func TestUserFeedback_DocFileWithFeedbackInNameIsRejected(t *testing.T) {
+	files := fstest.MapFS{
+		"docs/feedback-policy.md": {Data: []byte("# how we handle feedback")},
+	}
+	got := runOn(t, UserFeedback{}, files)
+	if got.Score != acmm.ScoreMissing {
+		t.Errorf("docs file mentioning feedback: score = %v, want missing", got.Score)
+	}
+}

--- a/internal/signals/l3/user_feedback.go
+++ b/internal/signals/l3/user_feedback.go
@@ -3,6 +3,7 @@ package l3
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"github.com/sroberts/plumbline/internal/scanner"
 	"github.com/sroberts/plumbline/internal/signals"
@@ -10,8 +11,23 @@ import (
 )
 
 var (
-	npsFileRE     = regexp.MustCompile(`(?i)(nps|csat|survey|feedback).*\.(ts|tsx|js|jsx|vue|py|go)$`)
+	// npsFileRE matches files whose basename contains a feedback-channel
+	// keyword in a frontend-language extension. The path constraint
+	// (userFeedbackPathRE) is what actually rules out false positives;
+	// this regex stays loose so legitimate names like `useNPSSurvey.ts`
+	// or `userFeedbackForm.tsx` still match.
+	npsFileRE = regexp.MustCompile(`(?i)(nps|csat|survey|feedback).*\.(ts|tsx|js|jsx|vue|py|go|rb|kt|swift)$`)
+
+	// feedbackTplRE matches GitHub issue templates dedicated to feedback.
 	feedbackTplRE = regexp.MustCompile(`(?i)\.github/ISSUE_TEMPLATE/(feedback|nps|survey)`)
+
+	// userFeedbackPathRE constrains npsFileRE matches to common app paths
+	// (web/src, src, app, frontend, ui, components). Plumbline's own source
+	// at internal/signals/l3/user_feedback.go was matching the legacy regex
+	// — this ensures the signal only fires for genuine user-facing
+	// feedback components, not for files that happen to have "feedback"
+	// in the name in any directory.
+	userFeedbackPathRE = regexp.MustCompile(`(?i)^(web|src|app|frontend|ui|components|pages|hooks|routes|lib)/`)
 )
 
 type UserFeedback struct{}
@@ -22,6 +38,8 @@ func (UserFeedback) Family() string    { return "feedback" }
 func (UserFeedback) Title() string     { return "User-feedback / NPS / survey channel wired up" }
 
 func (s UserFeedback) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Result {
+	// 1. A dedicated GitHub issue template for feedback / NPS / survey.
+	//    High-confidence: directory + filename together imply intent.
 	if path, ok := anyPathMatches(idx, feedbackTplRE); ok {
 		return acmm.Result{
 			Status:     acmm.StatusFound,
@@ -31,15 +49,27 @@ func (s UserFeedback) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Res
 			Evidence:   []acmm.Evidence{{Path: path}},
 		}
 	}
-	if path, ok := anyByNameMatches(idx, npsFileRE); ok {
+
+	// 2. An NPS/survey component in a *frontend-shaped* path. Both
+	//    constraints together (basename + parent dir) make false positives
+	//    much rarer.
+	for _, f := range idx.Files {
+		base := basename(f.Path)
+		if !npsFileRE.MatchString(base) {
+			continue
+		}
+		if !userFeedbackPathRE.MatchString(f.Path) {
+			continue
+		}
 		return acmm.Result{
 			Status:     acmm.StatusFound,
 			Score:      acmm.ScoreFound,
 			Confidence: acmm.ConfidenceMedium,
 			Method:     acmm.MethodFilenameMatch,
-			Evidence:   []acmm.Evidence{{Path: path}},
+			Evidence:   []acmm.Evidence{{Path: f.Path}},
 		}
 	}
+
 	return acmm.Result{
 		Status:     acmm.StatusMissing,
 		Score:      acmm.ScoreMissing,
@@ -50,10 +80,17 @@ func (s UserFeedback) Detect(_ context.Context, idx *scanner.RepoIndex) acmm.Res
 			"low confidence — name match only",
 		},
 		FixHint: "Add a lightweight user-feedback channel: an NPS / CSAT " +
-			"survey component (e.g. useNPSSurvey hook), or a " +
+			"survey component (e.g. web/src/hooks/useNPSSurvey.ts), or a " +
 			".github/ISSUE_TEMPLATE/feedback.md so users can report what " +
 			"shipped wrong.",
 	}
+}
+
+func basename(p string) string {
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		return p[i+1:]
+	}
+	return p
 }
 
 func init() {


### PR DESCRIPTION
Recommendation #5 from the codebase audit. The `(nps|csat|survey|feedback).*\.(ts|tsx|...|go)$` regex matched `internal/signals/l3/user_feedback.go` when plumbline scanned its own repo — a false positive baked into the L3=88% verdict shipped in v0.2.0.

## Fix
Keep the basename regex loose; require the path to start with a conventional frontend root (`web`/`src`/`app`/`frontend`/`ui`/`components`/`pages`/`hooks`/`routes`/`lib`).

## Effect on plumbline's self-verdict
`l3.user-feedback` Found → Missing. L3 score: 88% (7/8) → 75% (6/8). Still above 0.7 threshold, verdict still L3.

## Tests
- Self-source path is rejected
- Genuine NPS component (`web/src/hooks/useNPSSurvey.ts`) is found
- Doc file mentioning feedback is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)