### PR TITLE
tui: wrap footer hints to viewport width (closes #19)

### DIFF
--- a/internal/tui/footer_wrap_test.go
+++ b/internal/tui/footer_wrap_test.go
@@ -1,0 +1,155 @@
+// Tests that footer hint lines wrap to the current viewport width
+// instead of overflowing it. Closes issue #19. The previous bug was
+// that long keybinding strings like "[↑/↓] select   [enter] preview
+// [g] scope   [esc] back   [q] quit" overran narrow terminals,
+// pushing later content off-screen or wrapping mid-glyph.
+//
+// Tests intentionally check only footer-hint lines, not the full
+// rendered view: signal rows / level bars / target paths can be longer
+// than the viewport in narrow terminals (and will be addressed
+// separately). Footer hint overflow is the regression that motivated
+// the issue.
+package tui
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/sroberts/plumbline/internal/scanner"
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// footerMarkers identifies a rendered line as a footer hint by
+// looking for keybinding bracket syntax that styleHint lines use.
+var footerMarkers = []string{"[r]", "[g]", "[↑/↓]", "[esc", "[enter]", "[q]", "[y]", "[n/esc]"}
+
+// overflowingFooterLines returns rendered footer-hint lines that
+// exceed width (rune-aware, ANSI-stripped).
+func overflowingFooterLines(view string, width int) []string {
+	var bad []string
+	for _, line := range strings.Split(view, "\n") {
+		visible := ansi.Strip(line)
+		isFooter := false
+		for _, m := range footerMarkers {
+			if strings.Contains(visible, m) {
+				isFooter = true
+				break
+			}
+		}
+		if !isFooter {
+			continue
+		}
+		if utf8.RuneCountInString(visible) > width {
+			bad = append(bad, visible)
+		}
+	}
+	return bad
+}
+
+func newResultsModel(t *testing.T, width int) *model {
+	t.Helper()
+	idx, err := scanner.ScanFS(fstest.MapFS{
+		"README.md": &fstest.MapFile{Data: []byte("# r")},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("ScanFS: %v", err)
+	}
+	m := New(nil).(*model)
+	m.width = width
+	m.height = 30
+	m.screen = screenResults
+	m.report = acmm.Report{
+		Repo:    "/test",
+		Verdict: acmm.Verdict{Level: acmm.LevelInstructed, Name: "Instructed"},
+		Signals: []acmm.SignalResult{
+			{ID: "l2.agent-instructions", Status: acmm.StatusFound, Title: "Agent instructions"},
+			{ID: "l3.user-feedback", Status: acmm.StatusMissing, Title: "User feedback"},
+		},
+	}
+	m.idx = idx
+	return m
+}
+
+func TestFooterWrap_ResultsScreenAtNarrowWidth(t *testing.T) {
+	for _, w := range []int{40, 60, 80, 120} {
+		m := newResultsModel(t, w)
+		bad := overflowingFooterLines(m.View(), w)
+		if len(bad) > 0 {
+			t.Errorf("results @ width=%d: %d footer line(s) exceed width:\n  %s",
+				w, len(bad), strings.Join(bad, "\n  "))
+		}
+	}
+}
+
+func TestFooterWrap_DetailScreenAtNarrowWidth(t *testing.T) {
+	for _, w := range []int{40, 60, 80, 120} {
+		m := newResultsModel(t, w)
+		m.screen = screenDetail
+		m.cursor = 0
+		bad := overflowingFooterLines(m.View(), w)
+		if len(bad) > 0 {
+			t.Errorf("detail @ width=%d: %d footer line(s) exceed width:\n  %s",
+				w, len(bad), strings.Join(bad, "\n  "))
+		}
+	}
+}
+
+func TestFooterWrap_FixDoneScreenAtNarrowWidth(t *testing.T) {
+	for _, w := range []int{40, 60, 80, 120} {
+		m := newResultsModel(t, w)
+		m.screen = screenFixDone
+		m.fixApplied = false
+		bad := overflowingFooterLines(m.View(), w)
+		if len(bad) > 0 {
+			t.Errorf("fix-done @ width=%d: %d footer line(s) exceed width:\n  %s",
+				w, len(bad), strings.Join(bad, "\n  "))
+		}
+	}
+}
+
+func TestFooterWrap_SkillTargetsScreenAtNarrowWidth(t *testing.T) {
+	// SkillTargets footer is the longest in the TUI:
+	//   "[↑/↓] select   [enter] preview   [g] scope   [esc] back   [q] quit"
+	// — the regression that motivated #19.
+	for _, w := range []int{40, 60, 80, 120} {
+		m := newResultsModel(t, w)
+		m.screen = screenSkillTargets
+		bad := overflowingFooterLines(m.View(), w)
+		if len(bad) > 0 {
+			t.Errorf("skill-targets @ width=%d: %d footer line(s) exceed width:\n  %s",
+				w, len(bad), strings.Join(bad, "\n  "))
+		}
+	}
+}
+
+func TestRenderHint_WrapsAtViewWidth(t *testing.T) {
+	m := &model{width: 30}
+	hint := "[↑/↓] select   [enter] preview   [g] scope   [esc] back   [q] quit"
+	got := m.renderHint(hint)
+	for _, line := range strings.Split(got, "\n") {
+		visible := ansi.Strip(line)
+		if utf8.RuneCountInString(visible) > 30 {
+			t.Errorf("renderHint produced line %q (%d cols) > 30",
+				visible, utf8.RuneCountInString(visible))
+		}
+	}
+	// Should produce at least 2 lines for a 67-char hint at width 30.
+	if lines := strings.Split(got, "\n"); len(lines) < 2 {
+		t.Errorf("expected wrap into multiple lines, got %d", len(lines))
+	}
+}
+
+func TestRenderHint_ZeroWidthFallsBackTo80(t *testing.T) {
+	m := &model{width: 0}
+	hint := strings.Repeat("a ", 50) // 100 chars
+	got := m.renderHint(hint)
+	// At fallback width 80, "a " repeated 50 times wraps to 2 lines.
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Errorf("expected wrap at fallback width 80, got %d line(s)", len(lines))
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -555,7 +555,7 @@ func (m *model) renderResults() string {
 		hint += "   [i] install skill"
 	}
 	hint += "   [q] quit"
-	b.WriteString(styleHint.Render(hint))
+	b.WriteString(m.renderHint(hint))
 	return b.String()
 }
 
@@ -618,7 +618,7 @@ func (m *model) renderDetail() string {
 			hint = "[a] apply fix   [esc] back   [q] quit"
 		}
 	}
-	b.WriteString(styleHint.Render(hint))
+	b.WriteString(m.renderHint(hint))
 	return b.String()
 }
 
@@ -653,7 +653,7 @@ func (m *model) renderFixForm() string {
 		b.WriteString("\n\n")
 	}
 
-	b.WriteString(styleHint.Render("[tab/↓] next   [shift+tab/↑] prev   [enter] continue   [esc] cancel"))
+	b.WriteString(m.renderHint("[tab/↓] next   [shift+tab/↑] prev   [enter] continue   [esc] cancel"))
 	return b.String()
 }
 
@@ -693,7 +693,7 @@ func (m *model) renderFixPreview() string {
 	}
 
 	b.WriteString(styleMissing.Render("Apply this fix? "))
-	b.WriteString(styleHint.Render("[y] yes   [n/esc] cancel"))
+	b.WriteString(m.renderHint("[y] yes   [n/esc] cancel"))
 	return b.String()
 }
 
@@ -729,7 +729,7 @@ func (m *model) renderFixDone() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(styleHint.Render("[r] rescan   [esc/enter] back   [q] quit"))
+	b.WriteString(m.renderHint("[r] rescan   [esc/enter] back   [q] quit"))
 	return b.String()
 }
 
@@ -748,8 +748,8 @@ func (m *model) renderSkillTargets() string {
 	if m.skillGlobal {
 		scope = "user (global, ~/)"
 	}
-	b.WriteString(fmt.Sprintf("Scope: %s   ", styleHeader.Render(scope)))
-	b.WriteString(styleHint.Render("[g] toggle scope"))
+	b.WriteString(fmt.Sprintf("Scope: %s\n", styleHeader.Render(scope)))
+	b.WriteString(m.renderHint("[g] toggle scope"))
 	b.WriteString("\n\n")
 
 	targets := skill.Targets()
@@ -783,7 +783,7 @@ func (m *model) renderSkillTargets() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(styleHint.Render("[↑/↓] select   [enter] preview   [g] scope   [esc] back   [q] quit"))
+	b.WriteString(m.renderHint("[↑/↓] select   [enter] preview   [g] scope   [esc] back   [q] quit"))
 	return b.String()
 }
 
@@ -794,6 +794,17 @@ func (m *model) viewWidth() int {
 		return 80
 	}
 	return m.width
+}
+
+// renderHint word-wraps a footer hint to the current viewport width
+// and applies the hint style. Every screen's footer goes through this
+// so narrow terminals don't truncate keybindings (issue #19).
+func (m *model) renderHint(hint string) string {
+	w := m.viewWidth()
+	if w <= 0 {
+		w = 80
+	}
+	return styleHint.Render(textwrap.Wrap(hint, w))
 }
 
 func padStatus(s acmm.Status) string {


### PR DESCRIPTION
## Summary

- Footer keybinding hints in the TUI overran narrow terminals, pushing later content off-screen or wrapping mid-glyph (issue #19).
- Adds a `renderHint` helper that runs every footer hint through `textwrap.Wrap(hint, m.viewWidth())` so they fold cleanly at the current width. Replaces seven direct `styleHint.Render(...)` call sites.
- Moves the install-skill picker's `[g] toggle scope` hint onto its own line — concatenating it after `Scope: …` overflowed at 40-col widths even after wrapping.

## Test plan

- [x] New rune-aware footer-overflow tests across results / detail / fix-done / skill-targets screens at widths 40, 60, 80, 120
- [x] Direct unit tests for `renderHint` (wrapping at narrow width, fallback to 80 cols when width=0)
- [x] `go test -race ./...` passes
- [x] `gofmt -l .` clean, `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)