### PR TITLE
signal-set: bump to v2 with deprecation aliases

### DIFF
--- a/cmd/plumbline/aliases_test.go
+++ b/cmd/plumbline/aliases_test.go
@@ -1,0 +1,77 @@
+// End-to-end coverage for the v1 → v2 deprecation aliases. The unit
+// tests in internal/signals/aliases_test.go cover the resolver in
+// isolation; these exercise the full assess pipeline so a regression
+// in flag wiring or warning routing trips here.
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAlias_DeprecatedIncludeSignalRewritesAndWarns(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CLAUDE.md", "# c\n\n"+strings.Repeat("rule.\n", 25))
+
+	// Pass the v1 alias l2.claude-md. It should rewrite to
+	// l2.agent-instructions and the assess should still find the
+	// CLAUDE.md → Found verdict for that signal.
+	code, out, errOut := runCLI(t, "assess", "--json", "--include-signal", "l2.claude-md", dir)
+	if code != exitOK {
+		t.Fatalf("exit = %d; stderr: %s", code, errOut)
+	}
+	if !strings.Contains(out, `"l2.agent-instructions"`) {
+		t.Errorf("verdict JSON should include rewritten signal id; got:\n%s", out)
+	}
+	if !strings.Contains(errOut, "deprecated since signal-set") {
+		t.Errorf("expected deprecation warning on stderr; got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "l2.claude-md") {
+		t.Errorf("warning should name the deprecated id; got:\n%s", errOut)
+	}
+}
+
+func TestAlias_QuietSuppressesDeprecationWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "CLAUDE.md", "# c\n\n"+strings.Repeat("rule.\n", 25))
+
+	// --quiet routes warnings to io.Discard so JSON-only consumers
+	// stay machine-clean even when their pinned IDs are deprecated.
+	code, _, errOut := runCLI(t, "assess", "--quiet", "--json",
+		"--include-signal", "l2.copilot-instructions", dir)
+	if code != exitOK {
+		t.Fatalf("exit = %d; stderr: %s", code, errOut)
+	}
+	if strings.Contains(errOut, "deprecated") {
+		t.Errorf("--quiet should suppress deprecation warning; got:\n%s", errOut)
+	}
+}
+
+func TestAlias_UnknownSignalSetRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "README.md", "# r")
+
+	// v99 is not a known signal-set version; assess should refuse
+	// rather than silently fall back. Exit code 2 (cannot run) is
+	// the right shape per SPEC.md §4.
+	code, _, errOut := runCLI(t, "assess", "--signal-set", "v99", dir)
+	if code != exitCannotRun {
+		t.Errorf("exit = %d, want %d (stderr: %s)", code, exitCannotRun, errOut)
+	}
+	if !strings.Contains(errOut, "unknown --signal-set") {
+		t.Errorf("expected unknown-signal-set error, got:\n%s", errOut)
+	}
+}
+
+func TestAlias_PinnedToV1StillAccepted(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "README.md", "# r")
+
+	// CI gates pinned to --signal-set v1 must keep working through
+	// the deprecation cycle. Otherwise the "stable IDs" promise in
+	// SPEC.md §8.2.5 has a one-release escape hatch.
+	code, _, errOut := runCLI(t, "assess", "--signal-set", "v1", "--cli", dir)
+	if code != exitOK {
+		t.Errorf("exit = %d, want %d (stderr: %s)", code, exitOK, errOut)
+	}
+}

--- a/cmd/plumbline/assess.go
+++ b/cmd/plumbline/assess.go
@@ -92,6 +92,9 @@ func makeAssessRunE(flags *assessFlags, stdout, stderr io.Writer) func(*cobra.Co
 		if flags.eventsFmt != "" && flags.eventsFmt != "ndjson" && flags.eventsFmt != "text" {
 			return errCannotRun(fmt.Errorf("invalid --events %q (want ndjson|text)", flags.eventsFmt))
 		}
+		if err := validateSignalSet(flags.signalSet); err != nil {
+			return errCannotRun(err)
+		}
 
 		path := "."
 		if len(args) == 1 {
@@ -105,9 +108,19 @@ func makeAssessRunE(flags *assessFlags, stdout, stderr io.Writer) func(*cobra.Co
 
 		emitter := report.NewEventEmitter(stderr, flags.eventsFmt == "ndjson")
 
+		// Rewrite deprecated signal IDs (e.g. v1's l2.claude-md) to
+		// their current names. Warnings go to stderr unless suppressed
+		// by --quiet so JSON output stays machine-clean.
+		warnSink := io.Writer(stderr)
+		if flags.quiet {
+			warnSink = io.Discard
+		}
+		includeIDs, _ := signals.ResolveIDs(flags.includeSignal, warnSink)
+		excludeIDs, _ := signals.ResolveIDs(flags.excludeSignal, warnSink)
+
 		pipelineOpts := pipelineOptions{
-			IncludeSignal: flags.includeSignal,
-			ExcludeSignal: flags.excludeSignal,
+			IncludeSignal: includeIDs,
+			ExcludeSignal: excludeIDs,
 			LevelFilters:  flags.levelFilters,
 			FamilyFilters: flags.familyFilters,
 			Scoring:       scoring.Options{MinConfidence: confLevel},
@@ -401,6 +414,20 @@ func stdoutIsTerminal(w io.Writer) bool {
 		return false
 	}
 	return term.IsTerminal(int(f.Fd()))
+}
+
+// validateSignalSet checks --signal-set against the versions this
+// binary knows about. "latest" and the current SignalSetVersion are
+// always accepted. Older versions (v1) are accepted as well so CI
+// gates pinned to v1 keep working through the deprecation cycle —
+// the alias resolver handles the renamed-IDs side.
+func validateSignalSet(v string) error {
+	switch v {
+	case "", "latest", buildinfo.SignalSetVersion, "v1":
+		return nil
+	default:
+		return fmt.Errorf("unknown --signal-set %q (want latest|%s|v1)", v, buildinfo.SignalSetVersion)
+	}
 }
 
 func parseConfidence(s string) (acmm.Confidence, error) {

--- a/cmd/plumbline/assess_test.go
+++ b/cmd/plumbline/assess_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sroberts/plumbline/internal/buildinfo"
 	"github.com/sroberts/plumbline/pkg/acmm"
 )
 
@@ -54,8 +55,9 @@ func TestAssessJSON_FoundAllL2ReachesLevelTwo(t *testing.T) {
 	if report.Schema != "plumbline/v1" {
 		t.Errorf("schema = %q, want plumbline/v1", report.Schema)
 	}
-	if report.SignalSetVersion != "v1" {
-		t.Errorf("signal_set_version = %q, want v1", report.SignalSetVersion)
+	if report.SignalSetVersion != buildinfo.SignalSetVersion {
+		t.Errorf("signal_set_version = %q, want %q",
+			report.SignalSetVersion, buildinfo.SignalSetVersion)
 	}
 	if report.Verdict.Level != acmm.LevelInstructed {
 		t.Errorf("Verdict.Level = %d, want 2 (Instructed) for substantive CLAUDE.md", report.Verdict.Level)

--- a/cmd/plumbline/help.go
+++ b/cmd/plumbline/help.go
@@ -337,7 +337,7 @@ const helpCompatibility = `# Compatibility & Signal-Set Versioning
 
 Every Verdict carries:
   tool_version       e.g. 1.4.2 (semver)
-  signal_set_version e.g. v1   (rule-set major)
+  signal_set_version e.g. v2   (rule-set major)
 
 ## Within a major version of signal_set_version
 - New signals can be added (a previously-passing repo can pick up additional credit, never lose it).
@@ -348,9 +348,23 @@ Every Verdict carries:
 - Removing or renaming a signal.
 
 ## Pinning in CI
-Use '--signal-set v1' so the verdict cannot silently flip when plumbline upgrades:
+Use '--signal-set v2' so the verdict cannot silently flip when plumbline upgrades:
 
-  plumbline assess --fail-below 3 --signal-set v1
+  plumbline assess --fail-below 3 --signal-set v2
 
 If the pinned version is unavailable (retired, tool too old/new), exit code 3 fires with a migration message.
+
+## Deprecation aliases (v1 → v2)
+The following IDs were renamed; v1's names still work for one minor
+version but emit a deprecation warning to stderr and rewrite to the
+current ID. CI gates pinning '--signal-set v1' should migrate before
+the alias is removed.
+
+  l2.claude-md            → l2.agent-instructions
+  l2.copilot-instructions → l2.agent-instructions
+
+Reason: any one of CLAUDE.md / AGENTS.md / .github/copilot-instructions.md /
+.cursorrules / .windsurfrules satisfies the underlying signal — most teams
+use one agent and requiring directives for several is too strict.
+Pass --quiet to suppress the warning when the deprecation is known.
 `

--- a/cmd/plumbline/main_test.go
+++ b/cmd/plumbline/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/sroberts/plumbline/internal/buildinfo"
 )
 
 // runCLI is a test helper that invokes the CLI in-process.
@@ -39,7 +41,7 @@ func TestVersion_PlainText(t *testing.T) {
 	if !strings.Contains(out, "plumbline ") {
 		t.Errorf("expected version banner, got:\n%s", out)
 	}
-	if !strings.Contains(out, "signal-set: v1") {
+	if !strings.Contains(out, "signal-set: "+buildinfo.SignalSetVersion) {
 		t.Errorf("expected signal-set version line, got:\n%s", out)
 	}
 }
@@ -49,8 +51,9 @@ func TestVersion_JSON(t *testing.T) {
 	if code != exitOK {
 		t.Fatalf("expected exit %d, got %d", exitOK, code)
 	}
-	if !strings.Contains(out, `"signal_set_version": "v1"`) {
-		t.Errorf("expected signal_set_version field in JSON, got:\n%s", out)
+	want := `"signal_set_version": "` + buildinfo.SignalSetVersion + `"`
+	if !strings.Contains(out, want) {
+		t.Errorf("expected %s in JSON, got:\n%s", want, out)
 	}
 }
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -6,9 +6,15 @@ var (
 	Commit  = "unknown"
 )
 
-// SignalSetVersion is the current frozen signal-set version. Bumping this
-// is governed by the SPEC.md §7 compatibility policy.
-const SignalSetVersion = "v1"
+// SignalSetVersion is the current frozen signal-set version. Bumping
+// this is governed by the SPEC.md §8.2.5 compatibility policy: each
+// rename or merge requires a deprecation alias for at least one minor
+// version (see internal/signals/aliases.go).
+//
+// v1 → v2 (this release): l2.claude-md and l2.copilot-instructions
+// were merged into l2.agent-instructions. Both old IDs remain valid
+// as deprecation aliases that rewrite + warn on use.
+const SignalSetVersion = "v2"
 
 // Schema is the top-level $id prefix for published JSON Schemas.
 const Schema = "plumbline/v1"

--- a/internal/signals/aliases.go
+++ b/internal/signals/aliases.go
@@ -1,0 +1,130 @@
+package signals
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+)
+
+// Aliases maps a deprecated (older signal-set) ID to the current ID
+// it was renamed or merged into. SPEC.md §8.2.5 is the contract:
+// renames go through a deprecation cycle with a `compat:` alias for
+// at least one minor version.
+//
+// Each entry records:
+//   - From: the deprecated ID a caller may still pass
+//   - To:   the current ID the alias rewrites to
+//   - Since: the signal-set version where the rename happened
+//   - Reason: a one-line human-readable migration note
+//
+// New entries are added when a signal is renamed or merged, never
+// removed before the next major signal-set bump.
+type Alias struct {
+	From   string
+	To     string
+	Since  string
+	Reason string
+}
+
+// aliases is the package-level alias registry, keyed by the
+// deprecated ID for O(1) rewrite lookups. v1 → v2 renames live here.
+var aliases = map[string]Alias{
+	"l2.claude-md": {
+		From:   "l2.claude-md",
+		To:     "l2.agent-instructions",
+		Since:  "v2",
+		Reason: "merged into l2.agent-instructions: any one of CLAUDE.md / AGENTS.md / .github/copilot-instructions.md / .cursorrules / .windsurfrules satisfies the signal",
+	},
+	"l2.copilot-instructions": {
+		From:   "l2.copilot-instructions",
+		To:     "l2.agent-instructions",
+		Since:  "v2",
+		Reason: "merged into l2.agent-instructions: any one of CLAUDE.md / AGENTS.md / .github/copilot-instructions.md / .cursorrules / .windsurfrules satisfies the signal",
+	},
+}
+
+// warned tracks which deprecated IDs we've already warned about in
+// this process — one warning per ID per run, not per occurrence.
+// Without this, a CI invocation passing the same alias to both
+// --include-signal and --exclude-signal would print twice.
+var (
+	warnedMu sync.Mutex
+	warned   = map[string]bool{}
+)
+
+// ResolveID rewrites a deprecated signal ID to its current name.
+// The second return is true if a rewrite happened. IDs that aren't
+// aliased pass through unchanged with ok=false.
+func ResolveID(id string) (string, bool) {
+	a, ok := aliases[id]
+	if !ok {
+		return id, false
+	}
+	return a.To, true
+}
+
+// LookupAlias returns the full Alias entry for a deprecated ID, or
+// false if id is not deprecated. Useful when callers want to surface
+// the migration note (e.g. in --json verdicts) rather than just the
+// rewrite.
+func LookupAlias(id string) (Alias, bool) {
+	a, ok := aliases[id]
+	return a, ok
+}
+
+// AllAliases returns every registered alias in deterministic (From) order.
+// Used by `plumbline help compatibility` and tests.
+func AllAliases() []Alias {
+	out := make([]Alias, 0, len(aliases))
+	for _, a := range aliases {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].From < out[j].From })
+	return out
+}
+
+// ResolveIDs rewrites a slice of (possibly deprecated) IDs in place,
+// emitting one warning per deprecated ID to w. Pass io.Discard to
+// suppress warnings (tests, JSON-only output paths). Returns the
+// rewritten slice and the list of aliases that fired (deterministic
+// order, suitable for embedding in verdict JSON).
+func ResolveIDs(ids []string, w io.Writer) ([]string, []Alias) {
+	if len(ids) == 0 {
+		return ids, nil
+	}
+	out := make([]string, len(ids))
+	var fired []Alias
+	for i, id := range ids {
+		if a, ok := aliases[id]; ok {
+			out[i] = a.To
+			fired = append(fired, a)
+			warnOnce(w, a)
+			continue
+		}
+		out[i] = id
+	}
+	return out, fired
+}
+
+func warnOnce(w io.Writer, a Alias) {
+	if w == nil || w == io.Discard {
+		return
+	}
+	warnedMu.Lock()
+	defer warnedMu.Unlock()
+	if warned[a.From] {
+		return
+	}
+	warned[a.From] = true
+	fmt.Fprintf(w, "warning: signal %q is deprecated since signal-set %s; using %q instead (%s)\n",
+		a.From, a.Since, a.To, a.Reason)
+}
+
+// resetWarnedForTest clears the once-per-process warn cache. Tests
+// only — exposed via export_test.go.
+func resetWarnedForTest() {
+	warnedMu.Lock()
+	defer warnedMu.Unlock()
+	warned = map[string]bool{}
+}

--- a/internal/signals/aliases.go
+++ b/internal/signals/aliases.go
@@ -7,10 +7,9 @@ import (
 	"sync"
 )
 
-// Aliases maps a deprecated (older signal-set) ID to the current ID
-// it was renamed or merged into. SPEC.md §8.2.5 is the contract:
-// renames go through a deprecation cycle with a `compat:` alias for
-// at least one minor version.
+// Alias records a deprecated-to-current signal-ID rename. SPEC.md
+// §8.2.5 is the contract: renames go through a deprecation cycle with
+// a `compat:` alias for at least one minor version.
 //
 // Each entry records:
 //   - From: the deprecated ID a caller may still pass

--- a/internal/signals/aliases_registry_test.go
+++ b/internal/signals/aliases_registry_test.go
@@ -1,0 +1,29 @@
+package signals_test
+
+import (
+	"testing"
+
+	"github.com/sroberts/plumbline/internal/signals"
+
+	// Side-effect imports register every signal with signals.Default.
+	// We need them here because aliases.To: must point at a signal
+	// that actually exists; without these imports the Default registry
+	// is empty and the integrity check below would falsely fail.
+	_ "github.com/sroberts/plumbline/internal/signals/l2"
+	_ "github.com/sroberts/plumbline/internal/signals/l3"
+	_ "github.com/sroberts/plumbline/internal/signals/l4"
+	_ "github.com/sroberts/plumbline/internal/signals/l5"
+)
+
+func TestAllAliases_EveryTargetExists(t *testing.T) {
+	// An alias whose To: points at a non-existent signal would
+	// silently rewrite to a dead end. This integration test runs
+	// against the real registry (populated via init()) so a typo in
+	// aliases.go fails CI rather than at runtime.
+	for _, a := range signals.AllAliases() {
+		if _, ok := signals.Default.Get(a.To); !ok {
+			t.Errorf("alias %q -> %q: target not registered in Default registry",
+				a.From, a.To)
+		}
+	}
+}

--- a/internal/signals/aliases_test.go
+++ b/internal/signals/aliases_test.go
@@ -1,0 +1,104 @@
+package signals
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestResolveID_KnownAliasRewrites(t *testing.T) {
+	got, ok := ResolveID("l2.claude-md")
+	if !ok {
+		t.Fatal("ResolveID(l2.claude-md) ok=false; want true")
+	}
+	if got != "l2.agent-instructions" {
+		t.Errorf("ResolveID(l2.claude-md) = %q; want l2.agent-instructions", got)
+	}
+}
+
+func TestResolveID_UnknownPassesThrough(t *testing.T) {
+	got, ok := ResolveID("l3.coverage-gate")
+	if ok {
+		t.Error("ResolveID(l3.coverage-gate) ok=true; want false (not deprecated)")
+	}
+	if got != "l3.coverage-gate" {
+		t.Errorf("ResolveID(l3.coverage-gate) = %q; want passthrough", got)
+	}
+}
+
+func TestResolveIDs_RewritesMixedSlice(t *testing.T) {
+	ResetWarnedForTest()
+	in := []string{"l2.claude-md", "l3.coverage-gate", "l2.copilot-instructions"}
+	got, fired := ResolveIDs(in, io.Discard)
+	want := []string{"l2.agent-instructions", "l3.coverage-gate", "l2.agent-instructions"}
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q; want %q", i, got[i], want[i])
+		}
+	}
+	if len(fired) != 2 {
+		t.Errorf("fired = %d; want 2", len(fired))
+	}
+}
+
+func TestResolveIDs_WarnsOnceToWriter(t *testing.T) {
+	ResetWarnedForTest()
+	var w bytes.Buffer
+	// Pass the same deprecated ID twice; warning should fire once.
+	_, _ = ResolveIDs([]string{"l2.claude-md", "l2.claude-md"}, &w)
+	got := w.String()
+	count := strings.Count(got, "deprecated since signal-set")
+	if count != 1 {
+		t.Errorf("warned %d times; want 1\noutput: %q", count, got)
+	}
+	if !strings.Contains(got, "l2.claude-md") {
+		t.Errorf("warning omits deprecated ID:\n%s", got)
+	}
+	if !strings.Contains(got, "l2.agent-instructions") {
+		t.Errorf("warning omits target ID:\n%s", got)
+	}
+}
+
+func TestResolveIDs_DiscardSuppressesWarning(t *testing.T) {
+	ResetWarnedForTest()
+	_, _ = ResolveIDs([]string{"l2.claude-md"}, io.Discard)
+	// Pass a real writer next; should still fire (Discard didn't mark warned).
+	var w bytes.Buffer
+	_, _ = ResolveIDs([]string{"l2.claude-md"}, &w)
+	if !strings.Contains(w.String(), "deprecated") {
+		t.Errorf("Discard incorrectly marked alias as warned; got %q", w.String())
+	}
+}
+
+func TestAllAliases_Deterministic(t *testing.T) {
+	// Stable order is part of the public contract — `plumbline help
+	// compatibility` and verdict JSON output rely on it.
+	got1 := AllAliases()
+	got2 := AllAliases()
+	if len(got1) != len(got2) {
+		t.Fatalf("inconsistent length: %d vs %d", len(got1), len(got2))
+	}
+	for i := range got1 {
+		if got1[i].From != got2[i].From {
+			t.Errorf("non-deterministic order at i=%d: %q vs %q",
+				i, got1[i].From, got2[i].From)
+		}
+	}
+}
+
+func TestLookupAlias_KnownAndUnknown(t *testing.T) {
+	a, ok := LookupAlias("l2.claude-md")
+	if !ok {
+		t.Fatal("LookupAlias(l2.claude-md) ok=false")
+	}
+	if a.Since == "" || a.Reason == "" {
+		t.Errorf("alias missing Since/Reason: %+v", a)
+	}
+	if _, ok := LookupAlias("nope"); ok {
+		t.Error("LookupAlias(nope) should be false")
+	}
+}

--- a/internal/signals/export_test.go
+++ b/internal/signals/export_test.go
@@ -1,0 +1,6 @@
+package signals
+
+// ResetWarnedForTest is a test-only helper that clears the
+// once-per-process deprecation-warning cache so tests can verify
+// warning behavior across multiple subtests without leaking state.
+func ResetWarnedForTest() { resetWarnedForTest() }


### PR DESCRIPTION
## Summary

- Wires up the deprecation-alias mechanism that SPEC.md §8.2.5 already promised: renames keep working through one minor version with a stderr warning + automatic rewrite.
- Bumps `SignalSetVersion` from `v1` → `v2` because the catalog has materially changed (l2.claude-md and l2.copilot-instructions were merged into l2.agent-instructions before v0.1.0).
- `--signal-set v1` still accepted so existing CI gates keep working through the deprecation cycle. Unknown versions now exit with code 2 instead of being silently ignored.
- `--include-signal l2.claude-md` rewrites to `l2.agent-instructions`, prints one deprecation warning to stderr (suppressed by `--quiet` so JSON consumers stay machine-clean).

## Test plan

- [x] `internal/signals/aliases_test.go` — ResolveID, ResolveIDs, warn-once semantics, `io.Discard` suppression, AllAliases ordering, LookupAlias edge cases
- [x] `internal/signals/aliases_registry_test.go` — integrity check that every alias `To:` target is registered in the populated Default registry (lives outside `aliases_test.go` to avoid an import cycle with `internal/signals/lN/`)
- [x] `cmd/plumbline/aliases_test.go` — end-to-end via `assess`: deprecated `--include-signal` rewrites + warns, `--quiet` suppresses, unknown `--signal-set` rejected with exitCannotRun, `--signal-set v1` still accepted
- [x] Existing contract tests now pin to `buildinfo.SignalSetVersion` rather than the literal `"v1"` so they track the constant (minimum-touch update — only the value pin changed, not the test logic)
- [x] `go test -race ./...` passes; gofmt + vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)