### PR TITLE
report: replace SARIF stub with real 2.1.0 output

### DIFF
--- a/cmd/plumbline/assess.go
+++ b/cmd/plumbline/assess.go
@@ -378,9 +378,12 @@ func writeReport(r acmm.Report, format, outPath string, stdout io.Writer) error 
 		}
 		data = append(data, '\n')
 	case "sarif":
-		// SARIF stub: minimal valid SARIF 2.1.0 envelope so CI tools
-		// don't fail to parse. Full conversion lands later.
-		data = []byte(`{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}` + "\n")
+		var err error
+		data, err = report.SARIF(r)
+		if err != nil {
+			return err
+		}
+		data = append(data, '\n')
 	default:
 		return fmt.Errorf("unknown report format: %s", format)
 	}

--- a/cmd/plumbline/sarif_test.go
+++ b/cmd/plumbline/sarif_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSARIFReport_EndToEnd makes sure --report sarif emits a parseable
+// SARIF 2.1.0 document with at least one rule + result for a missing
+// signal. The unit tests in internal/report/sarif_test.go cover the
+// shape; this exercises the wiring through writeReport.
+func TestSARIFReport_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "README.md", "# r\n")
+
+	code, out, errOut := runCLI(t, "assess", "--report", "sarif", "--out", "-", dir)
+	if code != exitOK {
+		t.Fatalf("exit = %d (stderr: %s)", code, errOut)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if doc["version"] != "2.1.0" {
+		t.Errorf("version = %v, want 2.1.0", doc["version"])
+	}
+
+	// A bare repo with only README.md is missing l2.agent-instructions —
+	// that should show up as a SARIF result.
+	if !strings.Contains(out, `"l2.agent-instructions"`) {
+		t.Errorf("expected missing signal id in SARIF results, got:\n%s", out)
+	}
+	if !strings.Contains(out, `"error"`) {
+		t.Errorf("expected at least one error-severity finding, got:\n%s", out)
+	}
+}

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -1,0 +1,203 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sroberts/plumbline/internal/buildinfo"
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// SARIF emits a SARIF 2.1.0 document representing an acmm.Report. Each
+// missing or partial signal becomes one SARIF "result"; signals with
+// status `found` and `na` are omitted (they're not actionable findings).
+//
+// Why SARIF: GitHub's code-scanning surface ingests SARIF and renders
+// findings inline in PRs. Without SARIF, CI gates have to scrape JSON
+// or markdown. SPEC.md §9 names sarif as a first-class output format.
+//
+// Schema: SARIF 2.1.0 (OASIS) —
+// https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+//
+// Severity mapping (per SPEC.md §8.2.6 color palette):
+//
+//	missing → error
+//	partial → warning
+//	found   → omitted
+//	na      → omitted
+func SARIF(r acmm.Report) ([]byte, error) {
+	rules := make([]sarifRule, 0, len(r.Signals))
+	results := make([]sarifResult, 0, len(r.Signals))
+
+	for _, s := range r.Signals {
+		if s.Status == acmm.StatusFound || s.Status == acmm.StatusNA {
+			continue
+		}
+		rules = append(rules, sarifRule{
+			ID:               s.ID,
+			Name:             s.Title,
+			ShortDescription: sarifText{Text: s.Title},
+			HelpURI:          fmt.Sprintf("https://github.com/sroberts/plumbline/blob/main/SPEC.md#%s", s.ID),
+			Help:             sarifText{Text: s.FixHint},
+			DefaultConfiguration: &sarifConfig{
+				Level: severityFor(s.Status),
+			},
+			Properties: map[string]any{
+				"acmm.level":  int(s.Level),
+				"acmm.family": s.Family,
+			},
+		})
+		results = append(results, signalToResult(s))
+	}
+
+	doc := sarifDocument{
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Version: "2.1.0",
+		Runs: []sarifRun{{
+			Tool: sarifTool{
+				Driver: sarifDriver{
+					Name:           "plumbline",
+					Version:        buildinfo.Version,
+					InformationURI: "https://github.com/sroberts/plumbline",
+					Rules:          rules,
+					Properties: map[string]any{
+						"signal_set_version": r.SignalSetVersion,
+					},
+				},
+			},
+			Results: results,
+			Properties: map[string]any{
+				"acmm.level":      int(r.Verdict.Level),
+				"acmm.level_name": r.Verdict.Name,
+				"scanned_at":      r.ScannedAt,
+			},
+		}},
+	}
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+func signalToResult(s acmm.SignalResult) sarifResult {
+	msg := s.Title
+	if msg == "" {
+		msg = s.ID
+	}
+	res := sarifResult{
+		RuleID:  s.ID,
+		Level:   severityFor(s.Status),
+		Message: sarifText{Text: msg},
+		Properties: map[string]any{
+			"score":      s.Score,
+			"confidence": string(s.Confidence),
+			"method":     string(s.Method),
+		},
+	}
+	if len(s.Notes) > 0 {
+		// SARIF "result.message" already carries one human string;
+		// stash structured notes in properties so consumers can drill
+		// in without parsing the message text.
+		res.Properties["notes"] = s.Notes
+	}
+	for _, ev := range s.Evidence {
+		// SARIF "physicalLocation" requires a URI. Plumbline evidence
+		// is always repo-relative path, optionally with a line span.
+		loc := sarifLocation{
+			PhysicalLocation: sarifPhysicalLocation{
+				ArtifactLocation: sarifArtifactLocation{URI: ev.Path},
+			},
+		}
+		if ev.Span != nil {
+			loc.PhysicalLocation.Region = &sarifRegion{
+				StartLine: ev.Span.Start,
+				EndLine:   ev.Span.End,
+			}
+		}
+		res.Locations = append(res.Locations, loc)
+	}
+	return res
+}
+
+func severityFor(st acmm.Status) string {
+	switch st {
+	case acmm.StatusMissing:
+		return "error"
+	case acmm.StatusPartial:
+		return "warning"
+	default:
+		// StatusFound / StatusNA shouldn't reach here (filtered upstream),
+		// but if they do, "note" is the harmless fallback per SARIF
+		// 2.1.0 §3.27.10.
+		return "note"
+	}
+}
+
+// SARIF 2.1.0 envelope, modeled to match the spec's required fields.
+// We omit optional fields plumbline doesn't currently populate (taxonomies,
+// invocations, conversion); GitHub's ingestor accepts a minimal envelope.
+
+type sarifDocument struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool       sarifTool      `json:"tool"`
+	Results    []sarifResult  `json:"results"`
+	Properties map[string]any `json:"properties,omitempty"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string         `json:"name"`
+	Version        string         `json:"version,omitempty"`
+	InformationURI string         `json:"informationUri,omitempty"`
+	Rules          []sarifRule    `json:"rules,omitempty"`
+	Properties     map[string]any `json:"properties,omitempty"`
+}
+
+type sarifRule struct {
+	ID                   string         `json:"id"`
+	Name                 string         `json:"name,omitempty"`
+	ShortDescription     sarifText      `json:"shortDescription"`
+	HelpURI              string         `json:"helpUri,omitempty"`
+	Help                 sarifText      `json:"help,omitempty"`
+	DefaultConfiguration *sarifConfig   `json:"defaultConfiguration,omitempty"`
+	Properties           map[string]any `json:"properties,omitempty"`
+}
+
+type sarifConfig struct {
+	Level string `json:"level,omitempty"`
+}
+
+type sarifResult struct {
+	RuleID     string          `json:"ruleId"`
+	Level      string          `json:"level,omitempty"`
+	Message    sarifText       `json:"message"`
+	Locations  []sarifLocation `json:"locations,omitempty"`
+	Properties map[string]any  `json:"properties,omitempty"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           *sarifRegion          `json:"region,omitempty"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine,omitempty"`
+	EndLine   int `json:"endLine,omitempty"`
+}
+
+type sarifText struct {
+	Text string `json:"text"`
+}

--- a/internal/report/sarif_test.go
+++ b/internal/report/sarif_test.go
@@ -1,0 +1,213 @@
+package report
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+func sarifSampleReport() acmm.Report {
+	return acmm.Report{
+		Schema:           "plumbline/v1",
+		ToolVersion:      "test",
+		SignalSetVersion: "v1",
+		Repo:             "/repo",
+		ScannedAt:        "2026-04-28T15:00:00Z",
+		Verdict: acmm.Verdict{
+			Level:       acmm.LevelInstructed,
+			Name:        "Instructed",
+			LevelScores: map[acmm.Level]float64{acmm.LevelInstructed: 1.0},
+		},
+		Signals: []acmm.SignalResult{
+			{
+				ID: "l2.found-thing", Level: acmm.LevelInstructed, Family: "instructions",
+				Title: "Found thing", Status: acmm.StatusFound, Score: 1.0,
+				Confidence: acmm.ConfidenceHigh, Method: acmm.MethodFilenameMatch,
+			},
+			{
+				ID: "l2.missing-thing", Level: acmm.LevelInstructed, Family: "instructions",
+				Title: "Missing thing", Status: acmm.StatusMissing, Score: 0.0,
+				Confidence: acmm.ConfidenceMedium, Method: acmm.MethodContentRegex,
+				FixHint: "add a thing",
+				Notes:   []string{"why it matters"},
+				Evidence: []acmm.Evidence{
+					{Path: "README.md", Span: &acmm.LineSpan{Start: 1, End: 5}},
+				},
+			},
+			{
+				ID: "l3.partial-thing", Level: acmm.LevelMeasured, Family: "metrics",
+				Title: "Partial thing", Status: acmm.StatusPartial, Score: 0.5,
+				Confidence: acmm.ConfidenceLow, Method: acmm.MethodFilenameMatch,
+			},
+			{
+				ID: "l3.na-thing", Level: acmm.LevelMeasured, Family: "metrics",
+				Status: acmm.StatusNA, Score: 0.0,
+			},
+		},
+	}
+}
+
+func TestSARIF_EnvelopeShape(t *testing.T) {
+	out, err := SARIF(sarifSampleReport())
+	if err != nil {
+		t.Fatalf("SARIF: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if doc["version"] != "2.1.0" {
+		t.Errorf("version = %v, want 2.1.0", doc["version"])
+	}
+	if !strings.HasPrefix(doc["$schema"].(string), "https://") {
+		t.Errorf("$schema = %v, want https URL", doc["$schema"])
+	}
+	runs, ok := doc["runs"].([]any)
+	if !ok || len(runs) != 1 {
+		t.Fatalf("runs missing or not single-run: %v", doc["runs"])
+	}
+}
+
+func TestSARIF_OnlyEmitsActionableFindings(t *testing.T) {
+	// found and na signals are not actionable findings; SARIF results
+	// should only carry missing/partial.
+	out, _ := SARIF(sarifSampleReport())
+	var doc sarifDocument
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Runs) != 1 {
+		t.Fatalf("got %d runs, want 1", len(doc.Runs))
+	}
+	results := doc.Runs[0].Results
+	gotIDs := make([]string, len(results))
+	for i, r := range results {
+		gotIDs[i] = r.RuleID
+	}
+	wantIDs := map[string]bool{
+		"l2.missing-thing": true,
+		"l3.partial-thing": true,
+	}
+	if len(results) != len(wantIDs) {
+		t.Errorf("got %d results, want %d (ids=%v)", len(results), len(wantIDs), gotIDs)
+	}
+	for _, id := range gotIDs {
+		if !wantIDs[id] {
+			t.Errorf("unexpected result id %q (found/na should be omitted)", id)
+		}
+	}
+}
+
+func TestSARIF_SeverityMapping(t *testing.T) {
+	out, _ := SARIF(sarifSampleReport())
+	var doc sarifDocument
+	_ = json.Unmarshal(out, &doc)
+
+	got := map[string]string{}
+	for _, r := range doc.Runs[0].Results {
+		got[r.RuleID] = r.Level
+	}
+	if got["l2.missing-thing"] != "error" {
+		t.Errorf("missing → %q, want error", got["l2.missing-thing"])
+	}
+	if got["l3.partial-thing"] != "warning" {
+		t.Errorf("partial → %q, want warning", got["l3.partial-thing"])
+	}
+}
+
+func TestSARIF_RuleHasFixHintAndHelpURI(t *testing.T) {
+	out, _ := SARIF(sarifSampleReport())
+	var doc sarifDocument
+	_ = json.Unmarshal(out, &doc)
+
+	var rule *sarifRule
+	for i, r := range doc.Runs[0].Tool.Driver.Rules {
+		if r.ID == "l2.missing-thing" {
+			rule = &doc.Runs[0].Tool.Driver.Rules[i]
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("rule l2.missing-thing not in driver.rules")
+	}
+	if rule.Help.Text != "add a thing" {
+		t.Errorf("rule.help = %q, want fix hint", rule.Help.Text)
+	}
+	if !strings.Contains(rule.HelpURI, "l2.missing-thing") {
+		t.Errorf("rule.helpUri = %q, want signal-id deep-link", rule.HelpURI)
+	}
+}
+
+func TestSARIF_LocationCarriesEvidenceLineSpan(t *testing.T) {
+	out, _ := SARIF(sarifSampleReport())
+	var doc sarifDocument
+	_ = json.Unmarshal(out, &doc)
+
+	for _, r := range doc.Runs[0].Results {
+		if r.RuleID != "l2.missing-thing" {
+			continue
+		}
+		if len(r.Locations) != 1 {
+			t.Fatalf("got %d locations, want 1", len(r.Locations))
+		}
+		loc := r.Locations[0]
+		if loc.PhysicalLocation.ArtifactLocation.URI != "README.md" {
+			t.Errorf("location.uri = %q, want README.md",
+				loc.PhysicalLocation.ArtifactLocation.URI)
+		}
+		if loc.PhysicalLocation.Region == nil {
+			t.Fatal("location missing region (line span lost)")
+		}
+		if loc.PhysicalLocation.Region.StartLine != 1 ||
+			loc.PhysicalLocation.Region.EndLine != 5 {
+			t.Errorf("region = %+v, want lines 1-5", loc.PhysicalLocation.Region)
+		}
+		return
+	}
+	t.Fatal("l2.missing-thing not in results")
+}
+
+func TestSARIF_ResultPropertiesIncludeScoreAndConfidence(t *testing.T) {
+	out, _ := SARIF(sarifSampleReport())
+	var doc sarifDocument
+	_ = json.Unmarshal(out, &doc)
+
+	for _, r := range doc.Runs[0].Results {
+		if r.RuleID != "l2.missing-thing" {
+			continue
+		}
+		if r.Properties["confidence"] != "medium" {
+			t.Errorf("properties.confidence = %v, want medium", r.Properties["confidence"])
+		}
+		// JSON unmarshals numbers into float64; 0.0 is the score.
+		if r.Properties["method"] == nil {
+			t.Errorf("properties.method missing")
+		}
+		return
+	}
+	t.Fatal("l2.missing-thing not in results")
+}
+
+func TestSARIF_EmptyReportProducesValidEnvelope(t *testing.T) {
+	r := acmm.Report{
+		Schema:           "plumbline/v1",
+		ToolVersion:      "test",
+		SignalSetVersion: "v1",
+	}
+	out, err := SARIF(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc sarifDocument
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if len(doc.Runs) != 1 {
+		t.Errorf("len(runs) = %d, want 1", len(doc.Runs))
+	}
+	if len(doc.Runs[0].Results) != 0 {
+		t.Errorf("len(results) = %d, want 0", len(doc.Runs[0].Results))
+	}
+}


### PR DESCRIPTION
## Summary

The previous `--report sarif` emitted a one-line empty envelope. GitHub code-scanning would parse it but it carried no findings — the format was advertised, not implemented.

This PR ships a real SARIF 2.1.0 builder:

- Each missing/partial signal → one SARIF `result` + one declared `rule` in `tool.driver`. Severity: missing→error, partial→warning. Found/na filtered out.
- `rule.help` carries the FixHint so the GitHub UI renders "how to fix" inline. `rule.helpUri` deep-links to `SPEC.md#<signal-id>`.
- `result.locations` carries `Evidence{Path, Span}` as `physicalLocation.region` with start/end lines — findings attach to the right file/line.
- `result.properties` carries `score`, `confidence`, `method`, `notes` for consumers that want the structured detail.

## Test plan

- [x] `internal/report/sarif_test.go` — envelope shape, severity mapping, found/na filtering, rule help URI, evidence → location round-trip, properties round-trip, empty report still valid
- [x] `cmd/plumbline/sarif_test.go` — `--report sarif` end-to-end via `writeReport` on a bare repo
- [x] `go test -race ./...` passes; gofmt + vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)