### PR TITLE
assess: persist verdict history to NDJSON via --history-out

### DIFF
--- a/cmd/plumbline/assess.go
+++ b/cmd/plumbline/assess.go
@@ -47,6 +47,7 @@ type assessFlags struct {
 	excludeSignal []string
 	levelFilters  []int
 	familyFilters []string
+	historyOut    string
 }
 
 // bindAssessFlags registers the assess flag set on cmd. Used by the
@@ -73,6 +74,7 @@ func bindAssessFlags(cmd *cobra.Command, f *assessFlags) {
 	fs.StringSliceVar(&f.excludeSignal, "exclude-signal", nil, "Skip the listed signals. Repeatable.")
 	fs.IntSliceVar(&f.levelFilters, "level", nil, "Only run signals at level N (2-5). Repeatable.")
 	fs.StringSliceVar(&f.familyFilters, "family", nil, "Only run signals in family <name>. Repeatable.")
+	fs.StringVar(&f.historyOut, "history-out", "", "Append a one-line verdict summary (NDJSON) to this file. Useful for tracking maturity over time.")
 }
 
 // makeAssessRunE returns a cobra RunE closure that drives the assess
@@ -153,6 +155,18 @@ func makeAssessRunE(flags *assessFlags, stdout, stderr io.Writer) func(*cobra.Co
 			}
 		case !flags.quiet:
 			writeBriefText(stdout, rpt)
+		}
+
+		if flags.historyOut != "" {
+			if err := report.AppendHistory(flags.historyOut, report.SummarizeReport(rpt)); err != nil {
+				// Don't fail the assess on history-write failure; the
+				// verdict is the load-bearing output and a CI ratchet
+				// shouldn't break because /tmp filled up. Surface to
+				// stderr unless --quiet.
+				if !flags.quiet {
+					fmt.Fprintf(stderr, "warning: history append failed: %v\n", err)
+				}
+			}
 		}
 
 		if flags.failBelow > 0 && int(rpt.Verdict.Level) < flags.failBelow {

--- a/cmd/plumbline/history_test.go
+++ b/cmd/plumbline/history_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHistoryOut_AppendsOnePerInvocation(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "README.md", "# r\n")
+	hist := filepath.Join(dir, "maturity.ndjson")
+
+	for i := 0; i < 3; i++ {
+		code, _, errOut := runCLI(t, "assess", "--quiet",
+			"--history-out", hist, dir)
+		if code != exitOK {
+			t.Fatalf("assess #%d exit = %d (stderr: %s)", i, code, errOut)
+		}
+	}
+
+	data, err := os.ReadFile(hist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3 (after 3 invocations):\n%s", len(lines), data)
+	}
+	for i, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Errorf("line %d not valid JSON: %v\n%s", i, err, line)
+			continue
+		}
+		if _, ok := entry["level"]; !ok {
+			t.Errorf("line %d missing level field: %s", i, line)
+		}
+		if _, ok := entry["status_counts"]; !ok {
+			t.Errorf("line %d missing status_counts field: %s", i, line)
+		}
+	}
+}
+
+func TestHistoryOut_FailureDoesNotKillAssess(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "README.md", "# r\n")
+	// Point --history-out at a path whose parent directory doesn't exist.
+	// A history-write failure must not propagate to the assess exit code —
+	// otherwise CI ratchets break when /tmp fills up.
+	hist := filepath.Join(dir, "no", "such", "dir", "history.ndjson")
+
+	code, _, errOut := runCLI(t, "assess", "--history-out", hist, dir)
+	if code != exitOK {
+		t.Errorf("assess exit = %d, want %d (stderr: %s)", code, exitOK, errOut)
+	}
+	if !strings.Contains(errOut, "history append failed") {
+		t.Errorf("expected warning on stderr; got:\n%s", errOut)
+	}
+}

--- a/internal/report/history.go
+++ b/internal/report/history.go
@@ -1,0 +1,88 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+// HistoryEntry is one row of the maturity-history NDJSON file. Each
+// entry is a compact summary of a verdict — *not* the full report —
+// because the file is meant to be appended to repeatedly (per CI run,
+// per local invocation) and tracked over time. Storing the full
+// report on every assess would balloon the file and obscure the
+// signal in noise.
+//
+// Schema is intentionally narrow and append-only: new fields can be
+// added (consumers ignore unknowns) but existing field names will not
+// change without a major plumbline version bump, since downstream
+// dashboards and scripts pin to them.
+type HistoryEntry struct {
+	ScannedAt        string                 `json:"scanned_at"`
+	Repo             string                 `json:"repo,omitempty"`
+	ToolVersion      string                 `json:"tool_version,omitempty"`
+	SignalSetVersion string                 `json:"signal_set_version,omitempty"`
+	Level            acmm.Level             `json:"level"`
+	LevelName        string                 `json:"level_name,omitempty"`
+	LevelScores      map[acmm.Level]float64 `json:"level_scores,omitempty"`
+	StatusCounts     map[acmm.Status]int    `json:"status_counts"`
+}
+
+// SummarizeReport collapses a full Report into a HistoryEntry.
+func SummarizeReport(r acmm.Report) HistoryEntry {
+	counts := map[acmm.Status]int{
+		acmm.StatusFound:   0,
+		acmm.StatusPartial: 0,
+		acmm.StatusMissing: 0,
+		acmm.StatusNA:      0,
+	}
+	for _, s := range r.Signals {
+		counts[s.Status]++
+	}
+	return HistoryEntry{
+		ScannedAt:        r.ScannedAt,
+		Repo:             r.Repo,
+		ToolVersion:      r.ToolVersion,
+		SignalSetVersion: r.SignalSetVersion,
+		Level:            r.Verdict.Level,
+		LevelName:        r.Verdict.Name,
+		LevelScores:      r.Verdict.LevelScores,
+		StatusCounts:     counts,
+	}
+}
+
+// AppendHistory appends one HistoryEntry to the NDJSON file at path,
+// creating the file if it does not exist. Each entry is one line so
+// the file remains streamable and grep-friendly.
+//
+// O_APPEND is atomic on POSIX for writes within PIPE_BUF (4 KiB), so
+// concurrent CI jobs writing to the same file produce interleaved but
+// uncorrupted lines. A history entry is well under 1 KiB.
+func AppendHistory(path string, entry HistoryEntry) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open history file: %w", err)
+	}
+	defer f.Close()
+	return writeHistoryLine(f, entry)
+}
+
+// WriteHistoryLine encodes entry as one NDJSON line on w. Exposed for
+// callers that want to direct history elsewhere (e.g. an in-memory
+// buffer in tests, or stdout from a future `plumbline history` subcommand).
+func WriteHistoryLine(w io.Writer, entry HistoryEntry) error {
+	return writeHistoryLine(w, entry)
+}
+
+func writeHistoryLine(w io.Writer, entry HistoryEntry) error {
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal history entry: %w", err)
+	}
+	b = append(b, '\n')
+	_, err = w.Write(b)
+	return err
+}

--- a/internal/report/history_test.go
+++ b/internal/report/history_test.go
@@ -1,0 +1,113 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sroberts/plumbline/pkg/acmm"
+)
+
+func sampleHistorySource() acmm.Report {
+	return acmm.Report{
+		Schema:           "plumbline/v1",
+		ToolVersion:      "test",
+		SignalSetVersion: "v1",
+		Repo:             "/repo",
+		ScannedAt:        "2026-04-28T15:00:00Z",
+		Verdict: acmm.Verdict{
+			Level:       acmm.LevelInstructed,
+			Name:        "Instructed",
+			LevelScores: map[acmm.Level]float64{acmm.LevelInstructed: 1.0},
+		},
+		Signals: []acmm.SignalResult{
+			{ID: "a", Status: acmm.StatusFound},
+			{ID: "b", Status: acmm.StatusFound},
+			{ID: "c", Status: acmm.StatusPartial},
+			{ID: "d", Status: acmm.StatusMissing},
+			{ID: "e", Status: acmm.StatusNA},
+		},
+	}
+}
+
+func TestSummarizeReport_CountsAndCarriesVerdict(t *testing.T) {
+	got := SummarizeReport(sampleHistorySource())
+	if got.Level != acmm.LevelInstructed {
+		t.Errorf("Level = %v, want Instructed", got.Level)
+	}
+	if got.LevelName != "Instructed" {
+		t.Errorf("LevelName = %q", got.LevelName)
+	}
+	want := map[acmm.Status]int{
+		acmm.StatusFound: 2, acmm.StatusPartial: 1,
+		acmm.StatusMissing: 1, acmm.StatusNA: 1,
+	}
+	for k, v := range want {
+		if got.StatusCounts[k] != v {
+			t.Errorf("StatusCounts[%s] = %d, want %d", k, got.StatusCounts[k], v)
+		}
+	}
+}
+
+func TestWriteHistoryLine_OneNDJSONLine(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteHistoryLine(&buf, SummarizeReport(sampleHistorySource())); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Count(out, "\n") != 1 {
+		t.Errorf("expected exactly one newline; got %q", out)
+	}
+	var entry HistoryEntry
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &entry); err != nil {
+		t.Fatalf("not valid JSON: %v\nline: %q", err, out)
+	}
+}
+
+func TestAppendHistory_AppendsAcrossInvocations(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "maturity.ndjson")
+
+	r := sampleHistorySource()
+	if err := AppendHistory(path, SummarizeReport(r)); err != nil {
+		t.Fatal(err)
+	}
+	// Mutate scanned_at so the second entry is distinguishable, then append.
+	r.ScannedAt = "2026-04-29T15:00:00Z"
+	if err := AppendHistory(path, SummarizeReport(r)); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2 (content: %q)", len(lines), data)
+	}
+	for i, line := range lines {
+		var e HistoryEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %d not valid JSON: %v\n%s", i, err, line)
+		}
+	}
+}
+
+func TestAppendHistory_CreatesFileIfMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "dir", "history.ndjson")
+
+	// AppendHistory should fail cleanly here since we don't auto-mkdir.
+	// The error should mention the path, not crash.
+	err := AppendHistory(path, SummarizeReport(sampleHistorySource()))
+	if err == nil {
+		t.Errorf("expected error for missing parent dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "history") {
+		t.Errorf("error should be wrapped with context; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

A common ask: track maturity over time. Today every CI run either tosses the verdict or writes a fresh JSON that overwrites the prior one. Either way, plotting the climb from L1 → L3 means scraping commits or running plumbline N times yourself.

`plumbline assess --history-out <path>` appends one NDJSON line per invocation:

```json
{"scanned_at":"2026-04-28T15:00:00Z","repo":"/r","level":2,"level_name":"Instructed","level_scores":{...},"status_counts":{"found":12,"missing":3,"partial":1,"na":0}}
```

Compact summary (not the full report) is the right granularity for a long-running history file — full reports balloon the file and obscure trend signal. Schema is append-only.

History-write failure does **not** fail the assess. The verdict is the load-bearing output; a CI ratchet shouldn't break because `/tmp` filled up. Failures warn on stderr (suppressed by `--quiet`).

## Test plan

- [x] `internal/report/history_test.go` — SummarizeReport counts + carryover, WriteHistoryLine shape, AppendHistory creates+appends across invocations, AppendHistory wraps errors with context
- [x] `cmd/plumbline/history_test.go` — 3 invocations → 3 valid NDJSON lines end-to-end; failure mode does not kill assess (just warns)
- [x] `go test -race ./...` passes; gofmt + vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)