### PR TITLE
ci: wrap perf-budget step with retry@v3 (l4.error-recovery)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,17 @@ jobs:
         # bookkeeping, which would either force the budget so loose
         # it stops catching real regressions or make the gate flake.
         # Run perf-budget tests in a separate non-race invocation.
-        run: go test -count=1 -run "TestPerfBudget" ./internal/scanner/ ./internal/signals/
+        #
+        # Wrapped in retry@v3: the perf-budget tests have wall-clock
+        # ceilings (see internal/scanner/perf_budget_test.go) that
+        # can flake on busy CI runners. Three attempts costs <1 minute
+        # in the worst case and saves the build from a noisy CI runner
+        # erasing real signal. (l4.error-recovery)
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: go test -count=1 -run "TestPerfBudget" ./internal/scanner/ ./internal/signals/
 
       - name: coverage threshold
         run: |


### PR DESCRIPTION
## Summary

Wraps the perf-budget step (PR #26) with \`nick-fields/retry@v3\` (max_attempts: 3, timeout 5m).

## Why

The perf-budget tests have wall-clock ceilings (25-50ms) that absorb noise via generous limits but can still flake on busy CI runners — a Linux runner with another tenant under heavy load can blow past the budgets even though the underlying code is fine. Three attempts costs <1 minute in the worst case and saves real signal from being erased by noisy-neighbour CI scheduling.

The allocation gate inside those tests (which is deterministic) remains the load-bearing check; this just makes the wall-clock half robust.

Closes the ACMM L4 loop on flake-resilient automation (\`l4.error-recovery\`).

## Verification

\`\`\`
$ plumbline assess --json . | jq '.signals[] | select(.id == "l4.error-recovery").status'
"found"
\`\`\`

## Test plan

- [x] YAML parses
- [x] Step still runs the same \`go test ... TestPerfBudget\` command
- [x] retry@v3 schema correct (\`max_attempts\` + \`timeout_minutes\` + \`command\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)